### PR TITLE
feat: console chart env variables

### DIFF
--- a/components/kubefirst/console.yaml
+++ b/components/kubefirst/console.yaml
@@ -9,7 +9,7 @@ spec:
   project: default
   source:
     repoURL: https://kubefirst.github.io/charts
-    targetRevision: 1.0.1
+    targetRevision: 1.0.4
     chart: console
     helm:
       values: |-
@@ -24,6 +24,32 @@ spec:
             value: "<GITHUB_HOST>"
           GITHUB_OWNER:
             value: "<GITHUB_OWNER>"
+          ARGO_WORKFLOWS_URL:
+            value: "<ARGO_WORKFLOWS_URL>"
+          VAULT_URL:
+            value: "<VAULT_URL>"
+          ARGO_CD_URL:
+            value: "<ARGO_CD_URL>"
+          ATLANTIS_URL:
+            value: "<ATLANTIS_URL>"
+          METAPHOR_DEV:
+            value: "<METAPHOR_DEV>"
+          METAPHOR_GO_DEV:
+            value: "<METAPHOR_GO_DEV>"
+          METAPHOR_FRONT_DEV:
+            value: "<METAPHOR_FRONT_DEV>"
+          METAPHOR_STAGING:
+            value: "<METAPHOR_STAGING>"
+          METAPHOR_GO_STAGING:
+            value: "<METAPHOR_GO_STAGING>"
+          METAPHOR_FRONT_STAGING:
+            value: "<METAPHOR_FRONT_STAGING>"
+          METAPHOR_PROD:
+            value: "<METAPHOR_PROD>"
+          METAPHOR_GO_PROD:
+            value: "<METAPHOR_GO_PROD>"
+          METAPHOR_FRONT_PROD:
+            value: "<METAPHOR_FRONT_PROD>"
         ingress:
           enabled: true
           annotations:

--- a/localhost/components/kubefirst/console.yaml
+++ b/localhost/components/kubefirst/console.yaml
@@ -9,7 +9,7 @@ spec:
   project: default
   source:
     repoURL: https://kubefirst.github.io/charts
-    targetRevision: 1.0.2
+    targetRevision: 1.0.4
     chart: console
     helm:
       values: |-
@@ -24,6 +24,32 @@ spec:
             value: "<GITHUB_HOST>"
           GITHUB_OWNER:
             value: "<GITHUB_OWNER>"
+          ARGO_WORKFLOWS_URL:
+            value: "<ARGO_WORKFLOWS_URL>"
+          VAULT_URL:
+            value: "<VAULT_URL>"
+          ARGO_CD_URL:
+            value: "<ARGO_CD_URL>"
+          ATLANTIS_URL:
+            value: "<ATLANTIS_URL>"
+          METAPHOR_DEV:
+            value: "<METAPHOR_DEV>"
+          METAPHOR_GO_DEV:
+            value: "<METAPHOR_GO_DEV>"
+          METAPHOR_FRONT_DEV:
+            value: "<METAPHOR_FRONT_DEV>"
+          METAPHOR_STAGING:
+            value: "<METAPHOR_STAGING>"
+          METAPHOR_GO_STAGING:
+            value: "<METAPHOR_GO_STAGING>"
+          METAPHOR_FRONT_STAGING:
+            value: "<METAPHOR_FRONT_STAGING>"
+          METAPHOR_PROD:
+            value: "<METAPHOR_PROD>"
+          METAPHOR_GO_PROD:
+            value: "<METAPHOR_GO_PROD>"
+          METAPHOR_FRONT_PROD:
+            value: "<METAPHOR_FRONT_PROD>"
         ingress:
           enabled: false
   destination:


### PR DESCRIPTION
 - Adding new env variables for the console chart 
 
```bash
ARGO_WORKFLOWS_URL=
VAULT_URL=
ARGO_CD_URL=
ATLANTIS_URL=
METAPHOR_DEV=
METAPHOR_GO_DEV=
METAPHOR_FRONT_DEV=
METAPHOR_STAGING=
METAPHOR_GO_STAGING=
METAPHOR_FRONT_STAGING=
METAPHOR_PROD=
METAPHOR_GO_PROD=
METAPHOR_FRONT_PROD=
```