### PR TITLE
feat: add auto bump version ops template

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,13 @@
+{
+  "prHourlyLimit": 0,
+  "prConcurrentLimit": 0,
+  "enabledManagers": ["terraform", "argocd", "kustomize"],
+  "argocd": {
+    "fileMatch": ["templates/.+\\.yaml$"]
+  },
+  "terraform": {
+    "commitMessageTopic": "Terraform {{depName}}",
+    "fileMatch": ["\\.tf$"],
+    "pinDigests": false
+  }
+}


### PR DESCRIPTION
based on this comment from slack 
https://kubefirst.slack.com/archives/C03U34WJ7FW/p1703867034753859
 i though to have have such automated mechanism, would be a game changer for the ops template 
 
 that's why i came with a quick implementaiton of `renovate` 
 this bot will create PR for all argocd APP:kustomization and terraform .
 
 i make a the default setting for the AUTOMERGE( but can be easily change in the JSON file , we can discuss about it if you want) (all config options are [here](https://docs.renovatebot.com/configuration-options/)
 
 for me you can allow ALL to an AUTOmerge (in FF mode ) (fastforward merge lover here) .
 
 because you provide a template on a one time based . so no risk to break anything on update in customer side. ( but maybe i'm wrong about it)
 
 
 meanwhile, 
 you have to enable install the app trhough the github portal => https://github.com/apps/renovate 
 
 then i advise you to make firsly a silent config, like this you can check what is achieve by renovate.
 
 then allow only repository where a config file is present.
 
 
 more info about renovate [here](https://docs.renovatebot.com/)
 
 
 edit: you can check created MR on my fork https://github.com/DrummyFloyd/gitops-template/pulls?q=is%3Apr+is%3Aclosed
 
 to check how it's looked
 
 