### PR TITLE
feat(civo-github): add gpu operator to allow use of GPU nodes

### DIFF
--- a/akamai-github/templates/mgmt/components/crossplane/crossplane-system/crossplane-system.yaml
+++ b/akamai-github/templates/mgmt/components/crossplane/crossplane-system/crossplane-system.yaml
@@ -10,12 +10,12 @@ metadata:
 spec:
   project: default
   destination:
-    name: in-cluster 
+    name: in-cluster
     namespace: crossplane-system
   source:
     repoURL: https://charts.crossplane.io/stable
     chart: crossplane
-    targetRevision: 1.12.2
+    targetRevision: 1.16.0
   syncPolicy:
     automated:
       prune: true

--- a/aws-github/templates/mgmt/components/crossplane/crossplane-system/crossplane-system.yaml
+++ b/aws-github/templates/mgmt/components/crossplane/crossplane-system/crossplane-system.yaml
@@ -10,12 +10,12 @@ metadata:
 spec:
   project: default
   destination:
-    name: in-cluster 
+    name: in-cluster
     namespace: crossplane-system
   source:
     repoURL: https://charts.crossplane.io/stable
     chart: crossplane
-    targetRevision: 1.12.2
+    targetRevision: 1.16.0
   syncPolicy:
     automated:
       prune: true

--- a/aws-gitlab/templates/mgmt/components/crossplane/crossplane-system/crossplane-system.yaml
+++ b/aws-gitlab/templates/mgmt/components/crossplane/crossplane-system/crossplane-system.yaml
@@ -10,12 +10,12 @@ metadata:
 spec:
   project: default
   destination:
-    name: in-cluster 
+    name: in-cluster
     namespace: crossplane-system
   source:
     repoURL: https://charts.crossplane.io/stable
     chart: crossplane
-    targetRevision: 1.12.2
+    targetRevision: 1.16.0
   syncPolicy:
     automated:
       prune: true

--- a/civo-github/templates/mgmt/components/crossplane/crossplane-system/crossplane-system.yaml
+++ b/civo-github/templates/mgmt/components/crossplane/crossplane-system/crossplane-system.yaml
@@ -10,12 +10,12 @@ metadata:
 spec:
   project: default
   destination:
-    name: in-cluster 
+    name: in-cluster
     namespace: crossplane-system
   source:
     repoURL: https://charts.crossplane.io/stable
     chart: crossplane
-    targetRevision: 1.12.2
+    targetRevision: 1.16.0
   syncPolicy:
     automated:
       prune: true

--- a/civo-github/templates/mgmt/components/crossplane/provider/controllerconfig.yaml
+++ b/civo-github/templates/mgmt/components/crossplane/provider/controllerconfig.yaml
@@ -13,3 +13,10 @@ spec:
   envFrom:
   - secretRef:
       name: crossplane-secrets
+  volumeMounts:
+  - mountPath: /.cache
+    name: helmcache
+  volumes:
+    - name: helmcache
+      emptyDir:
+        sizeLimit: 500Mi

--- a/civo-github/templates/mgmt/components/crossplane/provider/terraform-provider.yaml
+++ b/civo-github/templates/mgmt/components/crossplane/provider/terraform-provider.yaml
@@ -13,4 +13,4 @@ spec:
   revisionActivationPolicy: Automatic
   revisionHistoryLimit: 1
   skipDependencyResolution: false
- 
+

--- a/civo-github/templates/workload-cluster/infrastructure/workspace.yaml
+++ b/civo-github/templates/workload-cluster/infrastructure/workspace.yaml
@@ -3,7 +3,7 @@ kind: Workspace
 metadata:
   name: <WORKLOAD_CLUSTER_NAME>-infrastructure
 spec:
-  providerConfigRef: 
+  providerConfigRef:
     name: <WORKLOAD_CLUSTER_NAME>
   forProvider:
     source: Remote

--- a/civo-github/templates/workload-cluster/provider-config/providerconfig.yaml
+++ b/civo-github/templates/workload-cluster/provider-config/providerconfig.yaml
@@ -24,6 +24,10 @@ spec:
             source  = "civo/civo"
             version = "~> 1.1.0"
           }
+          helm = {
+            source = "hashicorp/helm"
+            version = "~> 2.15.0"
+          }
         }
       }
       provider "civo" {

--- a/civo-github/terraform/civo/main.tf
+++ b/civo-github/terraform/civo/main.tf
@@ -13,7 +13,7 @@ terraform {
   }
   required_providers {
     civo = {
-      source = "civo/civo"
+      source  = "civo/civo"
       version = "~> 1.1.0"
     }
   }

--- a/civo-github/terraform/civo/modules/workload-cluster/gpu.tf
+++ b/civo-github/terraform/civo/modules/workload-cluster/gpu.tf
@@ -1,0 +1,290 @@
+# Configuration used to install the GPU operator
+
+locals {
+  gpu_node_sizes = [for i in data.civo_size.gpu.sizes : i.name]
+  gpu_prefixes   = ["g4g.", "an."] # Civo GPU sizes start with these prefixes - ensure to end with "." to avoid false positives
+  is_gpu         = contains(local.gpu_node_sizes, var.node_type)
+}
+
+# Get all the GPU node types
+data "civo_size" "gpu" {
+  filter {
+    key      = "name"
+    values   = local.gpu_prefixes
+    match_by = "re"
+  }
+  filter {
+    key    = "type"
+    values = ["kubernetes"]
+  }
+}
+
+# Create labels for the GPU operator namespace
+resource "kubernetes_namespace_v1" "gpu_operator_labels" {
+  count = local.is_gpu ? 1 : 0
+  metadata {
+    name = "gpu-operator"
+    labels = {
+      "pod-security.kubernetes.io/enforce" = "privileged"
+    }
+  }
+}
+
+# Helm release configuration for the Nvidia GPU operator
+resource "helm_release" "gpu_operator" {
+  count           = local.is_gpu ? 1 : 0
+  name            = "gpu-operator"
+  repository      = "https://helm.ngc.nvidia.com/nvidia"
+  chart           = "gpu-operator"
+  namespace       = kubernetes_namespace_v1.gpu_operator_labels[count.index].metadata[0].name
+  version         = "v24.6.0"
+  atomic          = true
+  cleanup_on_fail = true
+  reset_values    = true
+  wait            = true
+  # Values taken from Civo GPU operator
+  # @link https://github.com/civo-learn/civo-gpu-operator-tf/blob/cdb5bc6ac3d278e3a0285178c4960611639bf196/infra/tf/values/gpu-operator-values.yaml
+  values = [
+    yamlencode({
+      # set replica false as feature discovery remains pending
+      wait = true
+
+      ## Node Feature Discovery enabled/disable configuration.
+      nfd = {
+        enabled = true
+      }
+
+      # GPU Feature Discovery configuration.
+      gfd = {
+        enabled = true
+      }
+
+      # Operator configuration.
+      operator = {
+        upgradeCRD = true
+        cleanupCRD = true
+        resources = {
+          requests = {
+            cpu    = "10m"
+            memory = "100Mi"
+          }
+          limits = {
+            cpu    = "50m"
+            memory = "300Mi"
+          }
+        }
+      }
+
+      # Node Feature Discovery configuration.
+      node-feature-discovery = {
+        enableNodeFeatureApi = true
+        master = {
+          resources = {
+            requests = {
+              cpu    = "10m"
+              memory = "200Mi"
+            }
+          }
+        }
+        worker = {
+          resources = {
+            requests = {
+              cpu    = "10m"
+              memory = "100Mi"
+            }
+            limits = {
+              cpu    = "50m"
+              memory = "300Mi"
+            }
+          }
+          affinity = {
+            nodeAffinity = {
+              requiredDuringSchedulingIgnoredDuringExecution = {
+                nodeSelectorTerms = [
+                  {
+                    matchExpressions = [
+                      {
+                        key      = "node.kubernetes.io/instance-type"
+                        operator = "In"
+                        values   = local.gpu_node_sizes
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          }
+          tolerations = [
+            {
+              key      = "nvidia.com/gpu"
+              operator = "Exists"
+              effect   = "NoSchedule"
+            }
+          ]
+        }
+        gc = {
+          enable   = false
+          interval = "30m"
+          resources = {
+            requests = {
+              cpu    = "10m"
+              memory = "100Mi"
+            }
+          }
+          affinity = {
+            nodeAffinity = {
+              requiredDuringSchedulingIgnoredDuringExecution = {
+                nodeSelectorTerms = [
+                  {
+                    matchExpressions = [
+                      {
+                        key      = "node.kubernetes.io/instance-type"
+                        operator = "NotIn"
+                        values   = local.gpu_node_sizes
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          }
+          tolerations = [
+            {
+              key      = "nvidia.com/gpu"
+              operator = "Exists"
+              effect   = "NoSchedule"
+            }
+          ]
+        }
+      }
+
+      # Driver configuration
+      driver = {
+        enabled = false
+      }
+
+      # Toolkit configuration.
+      toolkit = {
+        enabled = false
+      }
+
+      # Device Plugin configuration.
+      devicePlugin = {
+        enabled = true
+        version = "v0.14.5"
+        env = [
+          {
+            name  = "FAIL_ON_INIT_ERROR"
+            value = "false"
+          }
+        ]
+      }
+
+      # DCGM configuration
+      dcgm = {
+        # enable with monitoring
+        enabled = false
+        resources = {
+          requests = {
+            cpu    = "10m"
+            memory = "100Mi"
+          }
+          limits = {
+            cpu    = "50m"
+            memory = "400Mi"
+          }
+        }
+      }
+
+      # DCGM Exporter configuration.
+      dcgmExporter = {
+        # enable with monitoring
+        enabled = false
+      }
+
+      # MIG Manager configuration.
+      migManager = {
+        # @skip civo-talos-gpu-operator.migManager.enabled
+        enabled = false
+      }
+      validator = {
+        enabled = false
+      }
+    })
+  ]
+}
+# as the host driver and the nvidia container toolkit are provided within Talos as Shims,
+# we need to create a daemonset that forces these to be marked as ready for the GPU operator
+# TODO: "productionise" this
+resource "kubernetes_daemonset" "fake_toolkit_ready" {
+  count = local.is_gpu ? 1 : 0
+  metadata {
+    name      = "fake-toolkit-ready"
+    namespace = kubernetes_namespace_v1.gpu_operator_labels[count.index].metadata[0].name
+  }
+  spec {
+    selector {
+      match_labels = {
+        "k8s-app" = "fake-toolkit-ready"
+      }
+    }
+    template {
+      metadata {
+        labels = {
+          name      = "fake-toolkit-ready"
+          "k8s-app" = "fake-toolkit-ready"
+        }
+      }
+      spec {
+        volume {
+          name = "run-nvidia"
+          host_path {
+            path = "/run/nvidia/validations/"
+          }
+        }
+        container {
+          name    = "main"
+          image   = "alpine:3.19"
+          command = ["sh", "-c"]
+          args = [
+            <<-EOF
+            set -ex;
+            touch /run/nvidia/validations/host-driver-ready;
+            touch /run/nvidia/validations/toolkit-ready;
+            touch /run/nvidia/validations/.driver-ctr-ready;
+            touch /run/nvidia/validations/driver-ready
+            sleep infinity
+            EOF
+          ]
+          volume_mount {
+            name              = "run-nvidia"
+            mount_path        = "/run/nvidia/validations/"
+            mount_propagation = "HostToContainer"
+          }
+          image_pull_policy = "IfNotPresent"
+        }
+        restart_policy = "Always"
+        affinity {
+          node_affinity {
+            required_during_scheduling_ignored_during_execution {
+              node_selector_term {
+                match_expressions {
+                  key      = "node.kubernetes.io/instance-type"
+                  operator = "In"
+                  values   = local.gpu_node_sizes
+                }
+              }
+            }
+          }
+        }
+        toleration {
+          key      = "nvidia.com/gpu"
+          operator = "Exists"
+          effect   = "NoSchedule"
+        }
+        priority_class_name = "system-node-critical"
+      }
+    }
+  }
+  depends_on = [helm_release.gpu_operator]
+}

--- a/civo-gitlab/templates/mgmt/components/crossplane/crossplane-system/crossplane-system.yaml
+++ b/civo-gitlab/templates/mgmt/components/crossplane/crossplane-system/crossplane-system.yaml
@@ -10,12 +10,12 @@ metadata:
 spec:
   project: default
   destination:
-    name: in-cluster 
+    name: in-cluster
     namespace: crossplane-system
   source:
     repoURL: https://charts.crossplane.io/stable
     chart: crossplane
-    targetRevision: 1.12.2
+    targetRevision: 1.16.0
   syncPolicy:
     automated:
       prune: true

--- a/digitalocean-github/templates/mgmt/components/crossplane/crossplane-system/crossplane-system.yaml
+++ b/digitalocean-github/templates/mgmt/components/crossplane/crossplane-system/crossplane-system.yaml
@@ -10,12 +10,12 @@ metadata:
 spec:
   project: default
   destination:
-    name: in-cluster 
+    name: in-cluster
     namespace: crossplane-system
   source:
     repoURL: https://charts.crossplane.io/stable
     chart: crossplane
-    targetRevision: 1.12.2
+    targetRevision: 1.16.0
   syncPolicy:
     automated:
       prune: true

--- a/digitalocean-gitlab/templates/mgmt/components/crossplane/crossplane-system/crossplane-system.yaml
+++ b/digitalocean-gitlab/templates/mgmt/components/crossplane/crossplane-system/crossplane-system.yaml
@@ -10,12 +10,12 @@ metadata:
 spec:
   project: default
   destination:
-    name: in-cluster 
+    name: in-cluster
     namespace: crossplane-system
   source:
     repoURL: https://charts.crossplane.io/stable
     chart: crossplane
-    targetRevision: 1.12.2
+    targetRevision: 1.16.0
   syncPolicy:
     automated:
       prune: true

--- a/google-github/templates/mgmt/components/crossplane/crossplane-system/crossplane-system.yaml
+++ b/google-github/templates/mgmt/components/crossplane/crossplane-system/crossplane-system.yaml
@@ -10,12 +10,12 @@ metadata:
 spec:
   project: default
   destination:
-    name: in-cluster 
+    name: in-cluster
     namespace: crossplane-system
   source:
     repoURL: https://charts.crossplane.io/stable
     chart: crossplane
-    targetRevision: 1.12.2
+    targetRevision: 1.16.0
   syncPolicy:
     automated:
       prune: true

--- a/google-gitlab/templates/mgmt/components/crossplane/crossplane-system/crossplane-system.yaml
+++ b/google-gitlab/templates/mgmt/components/crossplane/crossplane-system/crossplane-system.yaml
@@ -10,12 +10,12 @@ metadata:
 spec:
   project: default
   destination:
-    name: in-cluster 
+    name: in-cluster
     namespace: crossplane-system
   source:
     repoURL: https://charts.crossplane.io/stable
     chart: crossplane
-    targetRevision: 1.12.2
+    targetRevision: 1.16.0
   syncPolicy:
     automated:
       prune: true

--- a/k3d-github/cluster-types/mgmt/components/crossplane/crossplane-system/crossplane-system.yaml
+++ b/k3d-github/cluster-types/mgmt/components/crossplane/crossplane-system/crossplane-system.yaml
@@ -10,12 +10,12 @@ metadata:
 spec:
   project: default
   destination:
-    name: in-cluster 
+    name: in-cluster
     namespace: crossplane-system
   source:
     repoURL: https://charts.crossplane.io/stable
     chart: crossplane
-    targetRevision: 1.12.2
+    targetRevision: 1.16.0
   syncPolicy:
     automated:
       prune: true

--- a/k3d-gitlab/cluster-types/mgmt/components/crossplane/crossplane-system/crossplane-system.yaml
+++ b/k3d-gitlab/cluster-types/mgmt/components/crossplane/crossplane-system/crossplane-system.yaml
@@ -10,12 +10,12 @@ metadata:
 spec:
   project: default
   destination:
-    name: in-cluster 
+    name: in-cluster
     namespace: crossplane-system
   source:
     repoURL: https://charts.crossplane.io/stable
     chart: crossplane
-    targetRevision: 1.12.2
+    targetRevision: 1.16.0
   syncPolicy:
     automated:
       prune: true

--- a/k3s-github/templates/mgmt/components/crossplane/crossplane-system/crossplane-system.yaml
+++ b/k3s-github/templates/mgmt/components/crossplane/crossplane-system/crossplane-system.yaml
@@ -10,12 +10,12 @@ metadata:
 spec:
   project: default
   destination:
-    name: in-cluster 
+    name: in-cluster
     namespace: crossplane-system
   source:
     repoURL: https://charts.crossplane.io/stable
     chart: crossplane
-    targetRevision: 1.12.2
+    targetRevision: 1.16.0
   syncPolicy:
     automated:
       prune: true

--- a/k3s-gitlab/templates/mgmt/components/crossplane/crossplane-system/crossplane-system.yaml
+++ b/k3s-gitlab/templates/mgmt/components/crossplane/crossplane-system/crossplane-system.yaml
@@ -10,12 +10,12 @@ metadata:
 spec:
   project: default
   destination:
-    name: in-cluster 
+    name: in-cluster
     namespace: crossplane-system
   source:
     repoURL: https://charts.crossplane.io/stable
     chart: crossplane
-    targetRevision: 1.12.2
+    targetRevision: 1.16.0
   syncPolicy:
     automated:
       prune: true

--- a/vultr-github/templates/mgmt/components/crossplane/crossplane-system/crossplane-system.yaml
+++ b/vultr-github/templates/mgmt/components/crossplane/crossplane-system/crossplane-system.yaml
@@ -10,12 +10,12 @@ metadata:
 spec:
   project: default
   destination:
-    name: in-cluster 
+    name: in-cluster
     namespace: crossplane-system
   source:
     repoURL: https://charts.crossplane.io/stable
     chart: crossplane
-    targetRevision: 1.12.2
+    targetRevision: 1.16.0
   syncPolicy:
     automated:
       prune: true

--- a/vultr-gitlab/templates/mgmt/components/crossplane/crossplane-system/crossplane-system.yaml
+++ b/vultr-gitlab/templates/mgmt/components/crossplane/crossplane-system/crossplane-system.yaml
@@ -10,12 +10,12 @@ metadata:
 spec:
   project: default
   destination:
-    name: in-cluster 
+    name: in-cluster
     namespace: crossplane-system
   source:
     repoURL: https://charts.crossplane.io/stable
     chart: crossplane
-    targetRevision: 1.12.2
+    targetRevision: 1.16.0
   syncPolicy:
     automated:
       prune: true


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This is a piece of work that requires a bit of thought. For Civo-GitHub, I've added the ability to use GPU nodes. This requires some changes to how things work which could cause problems.

### Uncontroversial changes

- Install the NVIDIA GPU operator. This is based upon the work done in https://github.com/civo-learn/civo-gpu-operator-tf, but tailored it to our needs. I don't particularly like the `is_gpu` flag as it assumes that all GPU nodes start `g4g.` or `an.` which may not always be true - if anyone has a better idea how to achieve this, I'm all ears (I had hoped that `data.civo_size` would have it, but it doesn't).

### Controversial changes

- I've had to bump Crossplane to v1.16.0 (from v1.12.2). This is because I need to use the `helm_release` Terraform resource, which has a problem with the Crossplane provider not being able to download the charts (see https://github.com/crossplane-contrib/provider-terraform/issues/54). In order to fix this, I need to use an `emptyDir` volume mount on the Crossplane provider's pod and the v1.12.2 version of the CRD doesn't have it in `ControllerConfig.pkg.crossplane.io/v1alpha1`
- This means that `civo-github` has a different Crossplane version to all the other providers which I feel should probably be consistent.
- We probably should also switch from using `ControllerConfig` as it's [deprecated as of v1.11 and will be removed at some future date](https://docs.crossplane.io/latest/concepts/providers/#controller-configuration). Again, this is a big change to do across all providers.

## Related Issue(s)
<!-- List the issue(s) this PR solves. An issue should be raised before creating a PR -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

>* *IMPORTANT** the cheapest GPU node costs $1,200 per month ($1+ an hour) - don't leave it running.

1. Deploy Civo GitHub

```shell
/path/to/kubefirst civo create \
--alerts-email <EMAIL> \
--github-org <ORG> \
--cluster-name <NAME> \
--domain-name <DOMAIN> \
--gitops-template-branch sje/crossplane-version \
--cloud-region LON1
```

2. In the console, deploy a single node GPU cluster - suggest using a `g4g.40.kube.small` 
![image](https://github.com/user-attachments/assets/67aba56c-98ce-4002-8083-cacab0c8816d)