### PR TITLE
Akamai upgrade

### DIFF
--- a/akamai-github/templates/mgmt/components/argocd/kustomization.yaml
+++ b/akamai-github/templates/mgmt/components/argocd/kustomization.yaml
@@ -5,7 +5,7 @@ namespace: argocd
 # To upgrade ArgoCD, increment the version here
 # https://github.com/argoproj/argo-cd/tags
 resources:
-  - github.com:kubefirst/manifests.git/argocd/cloud?ref=main
+  - github.com:konstructio/manifests.git/argocd/cloud?ref=v1.1.0
   - argocd-ui-ingress.yaml
   - externalsecrets.yaml
   - argocd-oidc-restart-job.yaml

--- a/akamai-github/terraform/akamai/main.tf
+++ b/akamai-github/terraform/akamai/main.tf
@@ -35,7 +35,7 @@ locals {
 
 resource "linode_lke_cluster" "kubefirst" {
   label       = local.cluster_name
-  k8s_version = "1.28"
+  k8s_version = "1.30"
   region      = "us-central"
   tags        = ["<CLUSTER_NAME>"]
 


### PR DESCRIPTION
## Description
point argo verison to 2.12

## How to test
build the kubefirst binary locally and have kubefirst-api running locally,and run "./kubefirst beta akamai --alerts-email <ALERTS_EMAIL> --github-org <GITHUB_ORG> --gitops-template-branch akamai-upgrade --domain-name <DOMAIN_NAME> --cluster-name <CLUSTER_NAME>"
