### PR TITLE
feat,fix: Konstruct chart reference and K3d upgrade

### DIFF
--- a/akamai-github/templates/mgmt/components/kubefirst/console.yaml
+++ b/akamai-github/templates/mgmt/components/kubefirst/console.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   project: default
   source:
-    repoURL: https://charts.kubefirst.com
+    repoURL: https://charts.konstruct.io
     targetRevision: 2.4.14
     chart: kubefirst
     helm:

--- a/aws-github/templates/mgmt/components/kubefirst/console.yaml
+++ b/aws-github/templates/mgmt/components/kubefirst/console.yaml
@@ -9,7 +9,7 @@ spec:
   project: default
   source:
     repoURL: https://charts.kubefirst.com
-    targetRevision: 2.5.0-rc7
+    targetRevision: 2.5.0-rc8
     chart: kubefirst
     helm:
       values: |-

--- a/aws-github/templates/mgmt/components/kubefirst/console.yaml
+++ b/aws-github/templates/mgmt/components/kubefirst/console.yaml
@@ -9,7 +9,7 @@ spec:
   project: default
   source:
     repoURL: https://charts.kubefirst.com
-    targetRevision: 2.5.0-rc11
+    targetRevision: 2.5.0-rc12
     chart: kubefirst
     helm:
       values: |-

--- a/aws-github/templates/mgmt/components/kubefirst/console.yaml
+++ b/aws-github/templates/mgmt/components/kubefirst/console.yaml
@@ -9,7 +9,7 @@ spec:
   project: default
   source:
     repoURL: https://charts.kubefirst.com
-    targetRevision: 2.5.0-rc6
+    targetRevision: 2.5.0-rc7
     chart: kubefirst
     helm:
       values: |-

--- a/aws-github/templates/mgmt/components/kubefirst/console.yaml
+++ b/aws-github/templates/mgmt/components/kubefirst/console.yaml
@@ -9,7 +9,7 @@ spec:
   project: default
   source:
     repoURL: https://charts.kubefirst.com
-    targetRevision: 2.5.0-rc8
+    targetRevision: 2.5.0-rc9
     chart: kubefirst
     helm:
       values: |-

--- a/aws-github/templates/mgmt/components/kubefirst/console.yaml
+++ b/aws-github/templates/mgmt/components/kubefirst/console.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   project: default
   source:
-    repoURL: https://charts.kubefirst.com
+    repoURL: https://charts.konstruct.io
     targetRevision: 2.5.0-rc13
     chart: kubefirst
     helm:

--- a/aws-github/templates/mgmt/components/kubefirst/console.yaml
+++ b/aws-github/templates/mgmt/components/kubefirst/console.yaml
@@ -9,7 +9,7 @@ spec:
   project: default
   source:
     repoURL: https://charts.kubefirst.com
-    targetRevision: 2.4.17
+    targetRevision: 2.5.0-rc5
     chart: kubefirst
     helm:
       values: |-

--- a/aws-github/templates/mgmt/components/kubefirst/console.yaml
+++ b/aws-github/templates/mgmt/components/kubefirst/console.yaml
@@ -9,7 +9,7 @@ spec:
   project: default
   source:
     repoURL: https://charts.kubefirst.com
-    targetRevision: 2.5.0-rc12
+    targetRevision: 2.5.0-rc13
     chart: kubefirst
     helm:
       values: |-

--- a/aws-github/templates/mgmt/components/kubefirst/console.yaml
+++ b/aws-github/templates/mgmt/components/kubefirst/console.yaml
@@ -9,7 +9,7 @@ spec:
   project: default
   source:
     repoURL: https://charts.kubefirst.com
-    targetRevision: 2.5.0-rc9
+    targetRevision: 2.5.0-rc10
     chart: kubefirst
     helm:
       values: |-

--- a/aws-github/templates/mgmt/components/kubefirst/console.yaml
+++ b/aws-github/templates/mgmt/components/kubefirst/console.yaml
@@ -9,7 +9,7 @@ spec:
   project: default
   source:
     repoURL: https://charts.kubefirst.com
-    targetRevision: 2.5.0-rc5
+    targetRevision: 2.5.0-rc6
     chart: kubefirst
     helm:
       values: |-

--- a/aws-github/templates/mgmt/components/kubefirst/console.yaml
+++ b/aws-github/templates/mgmt/components/kubefirst/console.yaml
@@ -9,7 +9,7 @@ spec:
   project: default
   source:
     repoURL: https://charts.kubefirst.com
-    targetRevision: 2.5.0-rc10
+    targetRevision: 2.5.0-rc11
     chart: kubefirst
     helm:
       values: |-

--- a/aws-gitlab/templates/mgmt/components/kubefirst/console.yaml
+++ b/aws-gitlab/templates/mgmt/components/kubefirst/console.yaml
@@ -9,7 +9,7 @@ spec:
   project: default
   source:
     repoURL: https://charts.kubefirst.com
-    targetRevision: 2.5.0-rc7
+    targetRevision: 2.5.0-rc8
     chart: kubefirst
     helm:
       values: |-

--- a/aws-gitlab/templates/mgmt/components/kubefirst/console.yaml
+++ b/aws-gitlab/templates/mgmt/components/kubefirst/console.yaml
@@ -9,7 +9,7 @@ spec:
   project: default
   source:
     repoURL: https://charts.kubefirst.com
-    targetRevision: 2.5.0-rc11
+    targetRevision: 2.5.0-rc12
     chart: kubefirst
     helm:
       values: |-

--- a/aws-gitlab/templates/mgmt/components/kubefirst/console.yaml
+++ b/aws-gitlab/templates/mgmt/components/kubefirst/console.yaml
@@ -9,7 +9,7 @@ spec:
   project: default
   source:
     repoURL: https://charts.kubefirst.com
-    targetRevision: 2.5.0-rc6
+    targetRevision: 2.5.0-rc7
     chart: kubefirst
     helm:
       values: |-

--- a/aws-gitlab/templates/mgmt/components/kubefirst/console.yaml
+++ b/aws-gitlab/templates/mgmt/components/kubefirst/console.yaml
@@ -9,7 +9,7 @@ spec:
   project: default
   source:
     repoURL: https://charts.kubefirst.com
-    targetRevision: 2.5.0-rc8
+    targetRevision: 2.5.0-rc9
     chart: kubefirst
     helm:
       values: |-

--- a/aws-gitlab/templates/mgmt/components/kubefirst/console.yaml
+++ b/aws-gitlab/templates/mgmt/components/kubefirst/console.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   project: default
   source:
-    repoURL: https://charts.kubefirst.com
+    repoURL: https://charts.konstruct.io
     targetRevision: 2.5.0-rc13
     chart: kubefirst
     helm:

--- a/aws-gitlab/templates/mgmt/components/kubefirst/console.yaml
+++ b/aws-gitlab/templates/mgmt/components/kubefirst/console.yaml
@@ -9,7 +9,7 @@ spec:
   project: default
   source:
     repoURL: https://charts.kubefirst.com
-    targetRevision: 2.4.17
+    targetRevision: 2.5.0-rc5
     chart: kubefirst
     helm:
       values: |-

--- a/aws-gitlab/templates/mgmt/components/kubefirst/console.yaml
+++ b/aws-gitlab/templates/mgmt/components/kubefirst/console.yaml
@@ -9,7 +9,7 @@ spec:
   project: default
   source:
     repoURL: https://charts.kubefirst.com
-    targetRevision: 2.5.0-rc12
+    targetRevision: 2.5.0-rc13
     chart: kubefirst
     helm:
       values: |-

--- a/aws-gitlab/templates/mgmt/components/kubefirst/console.yaml
+++ b/aws-gitlab/templates/mgmt/components/kubefirst/console.yaml
@@ -9,7 +9,7 @@ spec:
   project: default
   source:
     repoURL: https://charts.kubefirst.com
-    targetRevision: 2.5.0-rc9
+    targetRevision: 2.5.0-rc10
     chart: kubefirst
     helm:
       values: |-

--- a/aws-gitlab/templates/mgmt/components/kubefirst/console.yaml
+++ b/aws-gitlab/templates/mgmt/components/kubefirst/console.yaml
@@ -9,7 +9,7 @@ spec:
   project: default
   source:
     repoURL: https://charts.kubefirst.com
-    targetRevision: 2.5.0-rc5
+    targetRevision: 2.5.0-rc6
     chart: kubefirst
     helm:
       values: |-

--- a/aws-gitlab/templates/mgmt/components/kubefirst/console.yaml
+++ b/aws-gitlab/templates/mgmt/components/kubefirst/console.yaml
@@ -9,7 +9,7 @@ spec:
   project: default
   source:
     repoURL: https://charts.kubefirst.com
-    targetRevision: 2.5.0-rc10
+    targetRevision: 2.5.0-rc11
     chart: kubefirst
     helm:
       values: |-

--- a/civo-github/templates/mgmt/components/kubefirst/console.yaml
+++ b/civo-github/templates/mgmt/components/kubefirst/console.yaml
@@ -9,7 +9,7 @@ spec:
   project: default
   source:
     repoURL: https://charts.kubefirst.com
-    targetRevision: 2.5.0-rc7
+    targetRevision: 2.5.0-rc8
     chart: kubefirst
     helm:
       values: |-

--- a/civo-github/templates/mgmt/components/kubefirst/console.yaml
+++ b/civo-github/templates/mgmt/components/kubefirst/console.yaml
@@ -9,7 +9,7 @@ spec:
   project: default
   source:
     repoURL: https://charts.kubefirst.com
-    targetRevision: 2.5.0-rc11
+    targetRevision: 2.5.0-rc12
     chart: kubefirst
     helm:
       values: |-

--- a/civo-github/templates/mgmt/components/kubefirst/console.yaml
+++ b/civo-github/templates/mgmt/components/kubefirst/console.yaml
@@ -9,7 +9,7 @@ spec:
   project: default
   source:
     repoURL: https://charts.kubefirst.com
-    targetRevision: 2.5.0-rc6
+    targetRevision: 2.5.0-rc7
     chart: kubefirst
     helm:
       values: |-

--- a/civo-github/templates/mgmt/components/kubefirst/console.yaml
+++ b/civo-github/templates/mgmt/components/kubefirst/console.yaml
@@ -9,7 +9,7 @@ spec:
   project: default
   source:
     repoURL: https://charts.kubefirst.com
-    targetRevision: 2.5.0-rc8
+    targetRevision: 2.5.0-rc9
     chart: kubefirst
     helm:
       values: |-

--- a/civo-github/templates/mgmt/components/kubefirst/console.yaml
+++ b/civo-github/templates/mgmt/components/kubefirst/console.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   project: default
   source:
-    repoURL: https://charts.kubefirst.com
+    repoURL: https://charts.konstruct.io
     targetRevision: 2.5.0-rc13
     chart: kubefirst
     helm:

--- a/civo-github/templates/mgmt/components/kubefirst/console.yaml
+++ b/civo-github/templates/mgmt/components/kubefirst/console.yaml
@@ -9,7 +9,7 @@ spec:
   project: default
   source:
     repoURL: https://charts.kubefirst.com
-    targetRevision: 2.4.17
+    targetRevision: 2.5.0-rc5
     chart: kubefirst
     helm:
       values: |-

--- a/civo-github/templates/mgmt/components/kubefirst/console.yaml
+++ b/civo-github/templates/mgmt/components/kubefirst/console.yaml
@@ -9,7 +9,7 @@ spec:
   project: default
   source:
     repoURL: https://charts.kubefirst.com
-    targetRevision: 2.5.0-rc12
+    targetRevision: 2.5.0-rc13
     chart: kubefirst
     helm:
       values: |-

--- a/civo-github/templates/mgmt/components/kubefirst/console.yaml
+++ b/civo-github/templates/mgmt/components/kubefirst/console.yaml
@@ -9,7 +9,7 @@ spec:
   project: default
   source:
     repoURL: https://charts.kubefirst.com
-    targetRevision: 2.5.0-rc9
+    targetRevision: 2.5.0-rc10
     chart: kubefirst
     helm:
       values: |-

--- a/civo-github/templates/mgmt/components/kubefirst/console.yaml
+++ b/civo-github/templates/mgmt/components/kubefirst/console.yaml
@@ -9,7 +9,7 @@ spec:
   project: default
   source:
     repoURL: https://charts.kubefirst.com
-    targetRevision: 2.5.0-rc5
+    targetRevision: 2.5.0-rc6
     chart: kubefirst
     helm:
       values: |-

--- a/civo-github/templates/mgmt/components/kubefirst/console.yaml
+++ b/civo-github/templates/mgmt/components/kubefirst/console.yaml
@@ -9,7 +9,7 @@ spec:
   project: default
   source:
     repoURL: https://charts.kubefirst.com
-    targetRevision: 2.5.0-rc10
+    targetRevision: 2.5.0-rc11
     chart: kubefirst
     helm:
       values: |-

--- a/civo-gitlab/templates/mgmt/components/kubefirst/console.yaml
+++ b/civo-gitlab/templates/mgmt/components/kubefirst/console.yaml
@@ -9,7 +9,7 @@ spec:
   project: default
   source:
     repoURL: https://charts.kubefirst.com
-    targetRevision: 2.5.0-rc7
+    targetRevision: 2.5.0-rc8
     chart: kubefirst
     helm:
       values: |-

--- a/civo-gitlab/templates/mgmt/components/kubefirst/console.yaml
+++ b/civo-gitlab/templates/mgmt/components/kubefirst/console.yaml
@@ -9,7 +9,7 @@ spec:
   project: default
   source:
     repoURL: https://charts.kubefirst.com
-    targetRevision: 2.5.0-rc11
+    targetRevision: 2.5.0-rc12
     chart: kubefirst
     helm:
       values: |-

--- a/civo-gitlab/templates/mgmt/components/kubefirst/console.yaml
+++ b/civo-gitlab/templates/mgmt/components/kubefirst/console.yaml
@@ -9,7 +9,7 @@ spec:
   project: default
   source:
     repoURL: https://charts.kubefirst.com
-    targetRevision: 2.5.0-rc6
+    targetRevision: 2.5.0-rc7
     chart: kubefirst
     helm:
       values: |-

--- a/civo-gitlab/templates/mgmt/components/kubefirst/console.yaml
+++ b/civo-gitlab/templates/mgmt/components/kubefirst/console.yaml
@@ -9,7 +9,7 @@ spec:
   project: default
   source:
     repoURL: https://charts.kubefirst.com
-    targetRevision: 2.5.0-rc8
+    targetRevision: 2.5.0-rc9
     chart: kubefirst
     helm:
       values: |-

--- a/civo-gitlab/templates/mgmt/components/kubefirst/console.yaml
+++ b/civo-gitlab/templates/mgmt/components/kubefirst/console.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   project: default
   source:
-    repoURL: https://charts.kubefirst.com
+    repoURL: https://charts.konstruct.io
     targetRevision: 2.5.0-rc13
     chart: kubefirst
     helm:

--- a/civo-gitlab/templates/mgmt/components/kubefirst/console.yaml
+++ b/civo-gitlab/templates/mgmt/components/kubefirst/console.yaml
@@ -9,7 +9,7 @@ spec:
   project: default
   source:
     repoURL: https://charts.kubefirst.com
-    targetRevision: 2.4.17
+    targetRevision: 2.5.0-rc5
     chart: kubefirst
     helm:
       values: |-

--- a/civo-gitlab/templates/mgmt/components/kubefirst/console.yaml
+++ b/civo-gitlab/templates/mgmt/components/kubefirst/console.yaml
@@ -9,7 +9,7 @@ spec:
   project: default
   source:
     repoURL: https://charts.kubefirst.com
-    targetRevision: 2.5.0-rc12
+    targetRevision: 2.5.0-rc13
     chart: kubefirst
     helm:
       values: |-

--- a/civo-gitlab/templates/mgmt/components/kubefirst/console.yaml
+++ b/civo-gitlab/templates/mgmt/components/kubefirst/console.yaml
@@ -9,7 +9,7 @@ spec:
   project: default
   source:
     repoURL: https://charts.kubefirst.com
-    targetRevision: 2.5.0-rc9
+    targetRevision: 2.5.0-rc10
     chart: kubefirst
     helm:
       values: |-

--- a/civo-gitlab/templates/mgmt/components/kubefirst/console.yaml
+++ b/civo-gitlab/templates/mgmt/components/kubefirst/console.yaml
@@ -9,7 +9,7 @@ spec:
   project: default
   source:
     repoURL: https://charts.kubefirst.com
-    targetRevision: 2.5.0-rc5
+    targetRevision: 2.5.0-rc6
     chart: kubefirst
     helm:
       values: |-

--- a/civo-gitlab/templates/mgmt/components/kubefirst/console.yaml
+++ b/civo-gitlab/templates/mgmt/components/kubefirst/console.yaml
@@ -9,7 +9,7 @@ spec:
   project: default
   source:
     repoURL: https://charts.kubefirst.com
-    targetRevision: 2.5.0-rc10
+    targetRevision: 2.5.0-rc11
     chart: kubefirst
     helm:
       values: |-

--- a/digitalocean-github/templates/mgmt/components/kubefirst/console.yaml
+++ b/digitalocean-github/templates/mgmt/components/kubefirst/console.yaml
@@ -9,7 +9,7 @@ spec:
   project: default
   source:
     repoURL: https://charts.kubefirst.com
-    targetRevision: 2.5.0-rc7
+    targetRevision: 2.5.0-rc8
     chart: kubefirst
     helm:
       values: |-

--- a/digitalocean-github/templates/mgmt/components/kubefirst/console.yaml
+++ b/digitalocean-github/templates/mgmt/components/kubefirst/console.yaml
@@ -9,7 +9,7 @@ spec:
   project: default
   source:
     repoURL: https://charts.kubefirst.com
-    targetRevision: 2.5.0-rc11
+    targetRevision: 2.5.0-rc12
     chart: kubefirst
     helm:
       values: |-

--- a/digitalocean-github/templates/mgmt/components/kubefirst/console.yaml
+++ b/digitalocean-github/templates/mgmt/components/kubefirst/console.yaml
@@ -9,7 +9,7 @@ spec:
   project: default
   source:
     repoURL: https://charts.kubefirst.com
-    targetRevision: 2.5.0-rc6
+    targetRevision: 2.5.0-rc7
     chart: kubefirst
     helm:
       values: |-

--- a/digitalocean-github/templates/mgmt/components/kubefirst/console.yaml
+++ b/digitalocean-github/templates/mgmt/components/kubefirst/console.yaml
@@ -9,7 +9,7 @@ spec:
   project: default
   source:
     repoURL: https://charts.kubefirst.com
-    targetRevision: 2.5.0-rc8
+    targetRevision: 2.5.0-rc9
     chart: kubefirst
     helm:
       values: |-

--- a/digitalocean-github/templates/mgmt/components/kubefirst/console.yaml
+++ b/digitalocean-github/templates/mgmt/components/kubefirst/console.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   project: default
   source:
-    repoURL: https://charts.kubefirst.com
+    repoURL: https://charts.konstruct.io
     targetRevision: 2.5.0-rc13
     chart: kubefirst
     helm:

--- a/digitalocean-github/templates/mgmt/components/kubefirst/console.yaml
+++ b/digitalocean-github/templates/mgmt/components/kubefirst/console.yaml
@@ -9,7 +9,7 @@ spec:
   project: default
   source:
     repoURL: https://charts.kubefirst.com
-    targetRevision: 2.4.17
+    targetRevision: 2.5.0-rc5
     chart: kubefirst
     helm:
       values: |-

--- a/digitalocean-github/templates/mgmt/components/kubefirst/console.yaml
+++ b/digitalocean-github/templates/mgmt/components/kubefirst/console.yaml
@@ -9,7 +9,7 @@ spec:
   project: default
   source:
     repoURL: https://charts.kubefirst.com
-    targetRevision: 2.5.0-rc12
+    targetRevision: 2.5.0-rc13
     chart: kubefirst
     helm:
       values: |-

--- a/digitalocean-github/templates/mgmt/components/kubefirst/console.yaml
+++ b/digitalocean-github/templates/mgmt/components/kubefirst/console.yaml
@@ -9,7 +9,7 @@ spec:
   project: default
   source:
     repoURL: https://charts.kubefirst.com
-    targetRevision: 2.5.0-rc9
+    targetRevision: 2.5.0-rc10
     chart: kubefirst
     helm:
       values: |-

--- a/digitalocean-github/templates/mgmt/components/kubefirst/console.yaml
+++ b/digitalocean-github/templates/mgmt/components/kubefirst/console.yaml
@@ -9,7 +9,7 @@ spec:
   project: default
   source:
     repoURL: https://charts.kubefirst.com
-    targetRevision: 2.5.0-rc5
+    targetRevision: 2.5.0-rc6
     chart: kubefirst
     helm:
       values: |-

--- a/digitalocean-github/templates/mgmt/components/kubefirst/console.yaml
+++ b/digitalocean-github/templates/mgmt/components/kubefirst/console.yaml
@@ -9,7 +9,7 @@ spec:
   project: default
   source:
     repoURL: https://charts.kubefirst.com
-    targetRevision: 2.5.0-rc10
+    targetRevision: 2.5.0-rc11
     chart: kubefirst
     helm:
       values: |-

--- a/digitalocean-gitlab/templates/mgmt/components/kubefirst/console.yaml
+++ b/digitalocean-gitlab/templates/mgmt/components/kubefirst/console.yaml
@@ -9,7 +9,7 @@ spec:
   project: default
   source:
     repoURL: https://charts.kubefirst.com
-    targetRevision: 2.5.0-rc7
+    targetRevision: 2.5.0-rc8
     chart: kubefirst
     helm:
       values: |-

--- a/digitalocean-gitlab/templates/mgmt/components/kubefirst/console.yaml
+++ b/digitalocean-gitlab/templates/mgmt/components/kubefirst/console.yaml
@@ -9,7 +9,7 @@ spec:
   project: default
   source:
     repoURL: https://charts.kubefirst.com
-    targetRevision: 2.5.0-rc11
+    targetRevision: 2.5.0-rc12
     chart: kubefirst
     helm:
       values: |-

--- a/digitalocean-gitlab/templates/mgmt/components/kubefirst/console.yaml
+++ b/digitalocean-gitlab/templates/mgmt/components/kubefirst/console.yaml
@@ -9,7 +9,7 @@ spec:
   project: default
   source:
     repoURL: https://charts.kubefirst.com
-    targetRevision: 2.5.0-rc6
+    targetRevision: 2.5.0-rc7
     chart: kubefirst
     helm:
       values: |-

--- a/digitalocean-gitlab/templates/mgmt/components/kubefirst/console.yaml
+++ b/digitalocean-gitlab/templates/mgmt/components/kubefirst/console.yaml
@@ -9,7 +9,7 @@ spec:
   project: default
   source:
     repoURL: https://charts.kubefirst.com
-    targetRevision: 2.5.0-rc8
+    targetRevision: 2.5.0-rc9
     chart: kubefirst
     helm:
       values: |-

--- a/digitalocean-gitlab/templates/mgmt/components/kubefirst/console.yaml
+++ b/digitalocean-gitlab/templates/mgmt/components/kubefirst/console.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   project: default
   source:
-    repoURL: https://charts.kubefirst.com
+    repoURL: https://charts.konstruct.io
     targetRevision: 2.5.0-rc13
     chart: kubefirst
     helm:

--- a/digitalocean-gitlab/templates/mgmt/components/kubefirst/console.yaml
+++ b/digitalocean-gitlab/templates/mgmt/components/kubefirst/console.yaml
@@ -9,7 +9,7 @@ spec:
   project: default
   source:
     repoURL: https://charts.kubefirst.com
-    targetRevision: 2.4.17
+    targetRevision: 2.5.0-rc5
     chart: kubefirst
     helm:
       values: |-

--- a/digitalocean-gitlab/templates/mgmt/components/kubefirst/console.yaml
+++ b/digitalocean-gitlab/templates/mgmt/components/kubefirst/console.yaml
@@ -9,7 +9,7 @@ spec:
   project: default
   source:
     repoURL: https://charts.kubefirst.com
-    targetRevision: 2.5.0-rc12
+    targetRevision: 2.5.0-rc13
     chart: kubefirst
     helm:
       values: |-

--- a/digitalocean-gitlab/templates/mgmt/components/kubefirst/console.yaml
+++ b/digitalocean-gitlab/templates/mgmt/components/kubefirst/console.yaml
@@ -9,7 +9,7 @@ spec:
   project: default
   source:
     repoURL: https://charts.kubefirst.com
-    targetRevision: 2.5.0-rc9
+    targetRevision: 2.5.0-rc10
     chart: kubefirst
     helm:
       values: |-

--- a/digitalocean-gitlab/templates/mgmt/components/kubefirst/console.yaml
+++ b/digitalocean-gitlab/templates/mgmt/components/kubefirst/console.yaml
@@ -9,7 +9,7 @@ spec:
   project: default
   source:
     repoURL: https://charts.kubefirst.com
-    targetRevision: 2.5.0-rc5
+    targetRevision: 2.5.0-rc6
     chart: kubefirst
     helm:
       values: |-

--- a/digitalocean-gitlab/templates/mgmt/components/kubefirst/console.yaml
+++ b/digitalocean-gitlab/templates/mgmt/components/kubefirst/console.yaml
@@ -9,7 +9,7 @@ spec:
   project: default
   source:
     repoURL: https://charts.kubefirst.com
-    targetRevision: 2.5.0-rc10
+    targetRevision: 2.5.0-rc11
     chart: kubefirst
     helm:
       values: |-

--- a/google-github/templates/mgmt/components/kubefirst/console.yaml
+++ b/google-github/templates/mgmt/components/kubefirst/console.yaml
@@ -9,7 +9,7 @@ spec:
   project: default
   source:
     repoURL: https://charts.kubefirst.com
-    targetRevision: 2.5.0-rc7
+    targetRevision: 2.5.0-rc8
     chart: kubefirst
     helm:
       values: |-

--- a/google-github/templates/mgmt/components/kubefirst/console.yaml
+++ b/google-github/templates/mgmt/components/kubefirst/console.yaml
@@ -9,7 +9,7 @@ spec:
   project: default
   source:
     repoURL: https://charts.kubefirst.com
-    targetRevision: 2.5.0-rc11
+    targetRevision: 2.5.0-rc12
     chart: kubefirst
     helm:
       values: |-

--- a/google-github/templates/mgmt/components/kubefirst/console.yaml
+++ b/google-github/templates/mgmt/components/kubefirst/console.yaml
@@ -9,7 +9,7 @@ spec:
   project: default
   source:
     repoURL: https://charts.kubefirst.com
-    targetRevision: 2.5.0-rc6
+    targetRevision: 2.5.0-rc7
     chart: kubefirst
     helm:
       values: |-

--- a/google-github/templates/mgmt/components/kubefirst/console.yaml
+++ b/google-github/templates/mgmt/components/kubefirst/console.yaml
@@ -9,7 +9,7 @@ spec:
   project: default
   source:
     repoURL: https://charts.kubefirst.com
-    targetRevision: 2.5.0-rc8
+    targetRevision: 2.5.0-rc9
     chart: kubefirst
     helm:
       values: |-

--- a/google-github/templates/mgmt/components/kubefirst/console.yaml
+++ b/google-github/templates/mgmt/components/kubefirst/console.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   project: default
   source:
-    repoURL: https://charts.kubefirst.com
+    repoURL: https://charts.konstruct.io
     targetRevision: 2.5.0-rc13
     chart: kubefirst
     helm:

--- a/google-github/templates/mgmt/components/kubefirst/console.yaml
+++ b/google-github/templates/mgmt/components/kubefirst/console.yaml
@@ -9,7 +9,7 @@ spec:
   project: default
   source:
     repoURL: https://charts.kubefirst.com
-    targetRevision: 2.4.17
+    targetRevision: 2.5.0-rc5
     chart: kubefirst
     helm:
       values: |-

--- a/google-github/templates/mgmt/components/kubefirst/console.yaml
+++ b/google-github/templates/mgmt/components/kubefirst/console.yaml
@@ -9,7 +9,7 @@ spec:
   project: default
   source:
     repoURL: https://charts.kubefirst.com
-    targetRevision: 2.5.0-rc12
+    targetRevision: 2.5.0-rc13
     chart: kubefirst
     helm:
       values: |-

--- a/google-github/templates/mgmt/components/kubefirst/console.yaml
+++ b/google-github/templates/mgmt/components/kubefirst/console.yaml
@@ -9,7 +9,7 @@ spec:
   project: default
   source:
     repoURL: https://charts.kubefirst.com
-    targetRevision: 2.5.0-rc9
+    targetRevision: 2.5.0-rc10
     chart: kubefirst
     helm:
       values: |-

--- a/google-github/templates/mgmt/components/kubefirst/console.yaml
+++ b/google-github/templates/mgmt/components/kubefirst/console.yaml
@@ -9,7 +9,7 @@ spec:
   project: default
   source:
     repoURL: https://charts.kubefirst.com
-    targetRevision: 2.5.0-rc5
+    targetRevision: 2.5.0-rc6
     chart: kubefirst
     helm:
       values: |-

--- a/google-github/templates/mgmt/components/kubefirst/console.yaml
+++ b/google-github/templates/mgmt/components/kubefirst/console.yaml
@@ -9,7 +9,7 @@ spec:
   project: default
   source:
     repoURL: https://charts.kubefirst.com
-    targetRevision: 2.5.0-rc10
+    targetRevision: 2.5.0-rc11
     chart: kubefirst
     helm:
       values: |-

--- a/google-gitlab/templates/mgmt/components/kubefirst/console.yaml
+++ b/google-gitlab/templates/mgmt/components/kubefirst/console.yaml
@@ -9,7 +9,7 @@ spec:
   project: default
   source:
     repoURL: https://charts.kubefirst.com
-    targetRevision: 2.5.0-rc7
+    targetRevision: 2.5.0-rc8
     chart: kubefirst
     helm:
       values: |-

--- a/google-gitlab/templates/mgmt/components/kubefirst/console.yaml
+++ b/google-gitlab/templates/mgmt/components/kubefirst/console.yaml
@@ -9,7 +9,7 @@ spec:
   project: default
   source:
     repoURL: https://charts.kubefirst.com
-    targetRevision: 2.5.0-rc11
+    targetRevision: 2.5.0-rc12
     chart: kubefirst
     helm:
       values: |-

--- a/google-gitlab/templates/mgmt/components/kubefirst/console.yaml
+++ b/google-gitlab/templates/mgmt/components/kubefirst/console.yaml
@@ -9,7 +9,7 @@ spec:
   project: default
   source:
     repoURL: https://charts.kubefirst.com
-    targetRevision: 2.5.0-rc6
+    targetRevision: 2.5.0-rc7
     chart: kubefirst
     helm:
       values: |-

--- a/google-gitlab/templates/mgmt/components/kubefirst/console.yaml
+++ b/google-gitlab/templates/mgmt/components/kubefirst/console.yaml
@@ -9,7 +9,7 @@ spec:
   project: default
   source:
     repoURL: https://charts.kubefirst.com
-    targetRevision: 2.5.0-rc8
+    targetRevision: 2.5.0-rc9
     chart: kubefirst
     helm:
       values: |-

--- a/google-gitlab/templates/mgmt/components/kubefirst/console.yaml
+++ b/google-gitlab/templates/mgmt/components/kubefirst/console.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   project: default
   source:
-    repoURL: https://charts.kubefirst.com
+    repoURL: https://charts.konstruct.io
     targetRevision: 2.5.0-rc13
     chart: kubefirst
     helm:

--- a/google-gitlab/templates/mgmt/components/kubefirst/console.yaml
+++ b/google-gitlab/templates/mgmt/components/kubefirst/console.yaml
@@ -9,7 +9,7 @@ spec:
   project: default
   source:
     repoURL: https://charts.kubefirst.com
-    targetRevision: 2.4.17
+    targetRevision: 2.5.0-rc5
     chart: kubefirst
     helm:
       values: |-

--- a/google-gitlab/templates/mgmt/components/kubefirst/console.yaml
+++ b/google-gitlab/templates/mgmt/components/kubefirst/console.yaml
@@ -9,7 +9,7 @@ spec:
   project: default
   source:
     repoURL: https://charts.kubefirst.com
-    targetRevision: 2.5.0-rc12
+    targetRevision: 2.5.0-rc13
     chart: kubefirst
     helm:
       values: |-

--- a/google-gitlab/templates/mgmt/components/kubefirst/console.yaml
+++ b/google-gitlab/templates/mgmt/components/kubefirst/console.yaml
@@ -9,7 +9,7 @@ spec:
   project: default
   source:
     repoURL: https://charts.kubefirst.com
-    targetRevision: 2.5.0-rc9
+    targetRevision: 2.5.0-rc10
     chart: kubefirst
     helm:
       values: |-

--- a/google-gitlab/templates/mgmt/components/kubefirst/console.yaml
+++ b/google-gitlab/templates/mgmt/components/kubefirst/console.yaml
@@ -9,7 +9,7 @@ spec:
   project: default
   source:
     repoURL: https://charts.kubefirst.com
-    targetRevision: 2.5.0-rc5
+    targetRevision: 2.5.0-rc6
     chart: kubefirst
     helm:
       values: |-

--- a/google-gitlab/templates/mgmt/components/kubefirst/console.yaml
+++ b/google-gitlab/templates/mgmt/components/kubefirst/console.yaml
@@ -9,7 +9,7 @@ spec:
   project: default
   source:
     repoURL: https://charts.kubefirst.com
-    targetRevision: 2.5.0-rc10
+    targetRevision: 2.5.0-rc11
     chart: kubefirst
     helm:
       values: |-

--- a/k3d-github/cluster-types/mgmt/components/argocd/kustomization.yaml
+++ b/k3d-github/cluster-types/mgmt/components/argocd/kustomization.yaml
@@ -5,7 +5,7 @@ namespace: argocd
 # To upgrade ArgoCD, increment the version here
 # https://github.com/argoproj/argo-cd/tags
 resources:
-  - github.com:argoproj/argo-cd.git/manifests/cluster-install?ref=v2.6.4
+  - github.com:argoproj/argo-cd.git/manifests/cluster-install?ref=v2.12.0
   - argocd-namespace.yaml
   - argocd-ui-ingress.yaml
   - argocd-ui-ingressroute.yaml

--- a/k3d-github/cluster-types/mgmt/components/kubefirst/console-arm.yaml
+++ b/k3d-github/cluster-types/mgmt/components/kubefirst/console-arm.yaml
@@ -9,7 +9,7 @@ spec:
   project: default
   source:
     repoURL: https://charts.kubefirst.com
-    targetRevision: 2.5.0-rc7
+    targetRevision: 2.5.0-rc8
     chart: kubefirst
     helm:
       values: |-

--- a/k3d-github/cluster-types/mgmt/components/kubefirst/console-arm.yaml
+++ b/k3d-github/cluster-types/mgmt/components/kubefirst/console-arm.yaml
@@ -9,7 +9,7 @@ spec:
   project: default
   source:
     repoURL: https://charts.kubefirst.com
-    targetRevision: 2.5.0-rc11
+    targetRevision: 2.5.0-rc12
     chart: kubefirst
     helm:
       values: |-

--- a/k3d-github/cluster-types/mgmt/components/kubefirst/console-arm.yaml
+++ b/k3d-github/cluster-types/mgmt/components/kubefirst/console-arm.yaml
@@ -9,7 +9,7 @@ spec:
   project: default
   source:
     repoURL: https://charts.kubefirst.com
-    targetRevision: 2.5.0-rc6
+    targetRevision: 2.5.0-rc7
     chart: kubefirst
     helm:
       values: |-

--- a/k3d-github/cluster-types/mgmt/components/kubefirst/console-arm.yaml
+++ b/k3d-github/cluster-types/mgmt/components/kubefirst/console-arm.yaml
@@ -9,7 +9,7 @@ spec:
   project: default
   source:
     repoURL: https://charts.kubefirst.com
-    targetRevision: 2.5.0-rc8
+    targetRevision: 2.5.0-rc9
     chart: kubefirst
     helm:
       values: |-

--- a/k3d-github/cluster-types/mgmt/components/kubefirst/console-arm.yaml
+++ b/k3d-github/cluster-types/mgmt/components/kubefirst/console-arm.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   project: default
   source:
-    repoURL: https://charts.kubefirst.com
+    repoURL: https://charts.konstruct.io
     targetRevision: 2.5.0-rc13
     chart: kubefirst
     helm:

--- a/k3d-github/cluster-types/mgmt/components/kubefirst/console-arm.yaml
+++ b/k3d-github/cluster-types/mgmt/components/kubefirst/console-arm.yaml
@@ -9,7 +9,7 @@ spec:
   project: default
   source:
     repoURL: https://charts.kubefirst.com
-    targetRevision: 2.4.17
+    targetRevision: 2.5.0-rc5
     chart: kubefirst
     helm:
       values: |-

--- a/k3d-github/cluster-types/mgmt/components/kubefirst/console-arm.yaml
+++ b/k3d-github/cluster-types/mgmt/components/kubefirst/console-arm.yaml
@@ -9,7 +9,7 @@ spec:
   project: default
   source:
     repoURL: https://charts.kubefirst.com
-    targetRevision: 2.5.0-rc12
+    targetRevision: 2.5.0-rc13
     chart: kubefirst
     helm:
       values: |-

--- a/k3d-github/cluster-types/mgmt/components/kubefirst/console-arm.yaml
+++ b/k3d-github/cluster-types/mgmt/components/kubefirst/console-arm.yaml
@@ -9,7 +9,7 @@ spec:
   project: default
   source:
     repoURL: https://charts.kubefirst.com
-    targetRevision: 2.5.0-rc9
+    targetRevision: 2.5.0-rc10
     chart: kubefirst
     helm:
       values: |-

--- a/k3d-github/cluster-types/mgmt/components/kubefirst/console-arm.yaml
+++ b/k3d-github/cluster-types/mgmt/components/kubefirst/console-arm.yaml
@@ -9,7 +9,7 @@ spec:
   project: default
   source:
     repoURL: https://charts.kubefirst.com
-    targetRevision: 2.5.0-rc5
+    targetRevision: 2.5.0-rc6
     chart: kubefirst
     helm:
       values: |-

--- a/k3d-github/cluster-types/mgmt/components/kubefirst/console-arm.yaml
+++ b/k3d-github/cluster-types/mgmt/components/kubefirst/console-arm.yaml
@@ -9,7 +9,7 @@ spec:
   project: default
   source:
     repoURL: https://charts.kubefirst.com
-    targetRevision: 2.5.0-rc10
+    targetRevision: 2.5.0-rc11
     chart: kubefirst
     helm:
       values: |-

--- a/k3d-github/cluster-types/mgmt/components/kubefirst/console.yaml
+++ b/k3d-github/cluster-types/mgmt/components/kubefirst/console.yaml
@@ -9,7 +9,7 @@ spec:
   project: default
   source:
     repoURL: https://charts.kubefirst.com
-    targetRevision: 2.5.0-rc7
+    targetRevision: 2.5.0-rc8
     chart: kubefirst
     helm:
       values: |-

--- a/k3d-github/cluster-types/mgmt/components/kubefirst/console.yaml
+++ b/k3d-github/cluster-types/mgmt/components/kubefirst/console.yaml
@@ -9,7 +9,7 @@ spec:
   project: default
   source:
     repoURL: https://charts.kubefirst.com
-    targetRevision: 2.5.0-rc11
+    targetRevision: 2.5.0-rc12
     chart: kubefirst
     helm:
       values: |-

--- a/k3d-github/cluster-types/mgmt/components/kubefirst/console.yaml
+++ b/k3d-github/cluster-types/mgmt/components/kubefirst/console.yaml
@@ -9,7 +9,7 @@ spec:
   project: default
   source:
     repoURL: https://charts.kubefirst.com
-    targetRevision: 2.5.0-rc6
+    targetRevision: 2.5.0-rc7
     chart: kubefirst
     helm:
       values: |-

--- a/k3d-github/cluster-types/mgmt/components/kubefirst/console.yaml
+++ b/k3d-github/cluster-types/mgmt/components/kubefirst/console.yaml
@@ -9,7 +9,7 @@ spec:
   project: default
   source:
     repoURL: https://charts.kubefirst.com
-    targetRevision: 2.5.0-rc8
+    targetRevision: 2.5.0-rc9
     chart: kubefirst
     helm:
       values: |-

--- a/k3d-github/cluster-types/mgmt/components/kubefirst/console.yaml
+++ b/k3d-github/cluster-types/mgmt/components/kubefirst/console.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   project: default
   source:
-    repoURL: https://charts.kubefirst.com
+    repoURL: https://charts.konstruct.io
     targetRevision: 2.5.0-rc13
     chart: kubefirst
     helm:

--- a/k3d-github/cluster-types/mgmt/components/kubefirst/console.yaml
+++ b/k3d-github/cluster-types/mgmt/components/kubefirst/console.yaml
@@ -9,7 +9,7 @@ spec:
   project: default
   source:
     repoURL: https://charts.kubefirst.com
-    targetRevision: 2.4.17
+    targetRevision: 2.5.0-rc5
     chart: kubefirst
     helm:
       values: |-

--- a/k3d-github/cluster-types/mgmt/components/kubefirst/console.yaml
+++ b/k3d-github/cluster-types/mgmt/components/kubefirst/console.yaml
@@ -9,7 +9,7 @@ spec:
   project: default
   source:
     repoURL: https://charts.kubefirst.com
-    targetRevision: 2.5.0-rc12
+    targetRevision: 2.5.0-rc13
     chart: kubefirst
     helm:
       values: |-

--- a/k3d-github/cluster-types/mgmt/components/kubefirst/console.yaml
+++ b/k3d-github/cluster-types/mgmt/components/kubefirst/console.yaml
@@ -9,7 +9,7 @@ spec:
   project: default
   source:
     repoURL: https://charts.kubefirst.com
-    targetRevision: 2.5.0-rc9
+    targetRevision: 2.5.0-rc10
     chart: kubefirst
     helm:
       values: |-

--- a/k3d-github/cluster-types/mgmt/components/kubefirst/console.yaml
+++ b/k3d-github/cluster-types/mgmt/components/kubefirst/console.yaml
@@ -9,7 +9,7 @@ spec:
   project: default
   source:
     repoURL: https://charts.kubefirst.com
-    targetRevision: 2.5.0-rc5
+    targetRevision: 2.5.0-rc6
     chart: kubefirst
     helm:
       values: |-

--- a/k3d-github/cluster-types/mgmt/components/kubefirst/console.yaml
+++ b/k3d-github/cluster-types/mgmt/components/kubefirst/console.yaml
@@ -9,7 +9,7 @@ spec:
   project: default
   source:
     repoURL: https://charts.kubefirst.com
-    targetRevision: 2.5.0-rc10
+    targetRevision: 2.5.0-rc11
     chart: kubefirst
     helm:
       values: |-

--- a/k3d-gitlab/cluster-types/mgmt/components/argocd/kustomization.yaml
+++ b/k3d-gitlab/cluster-types/mgmt/components/argocd/kustomization.yaml
@@ -5,7 +5,7 @@ namespace: argocd
 # To upgrade ArgoCD, increment the version here
 # https://github.com/argoproj/argo-cd/tags
 resources:
-  - github.com:argoproj/argo-cd.git/manifests/cluster-install?ref=v2.6.4
+  - github.com:argoproj/argo-cd.git/manifests/cluster-install?ref=v2.12.0
   - argocd-namespace.yaml
   - argocd-ui-ingress.yaml
   - argocd-ui-ingressroute.yaml

--- a/k3d-gitlab/cluster-types/mgmt/components/kubefirst/console-arm.yaml
+++ b/k3d-gitlab/cluster-types/mgmt/components/kubefirst/console-arm.yaml
@@ -9,7 +9,7 @@ spec:
   project: default
   source:
     repoURL: https://charts.kubefirst.com
-    targetRevision: 2.5.0-rc7
+    targetRevision: 2.5.0-rc8
     chart: kubefirst
     helm:
       values: |-

--- a/k3d-gitlab/cluster-types/mgmt/components/kubefirst/console-arm.yaml
+++ b/k3d-gitlab/cluster-types/mgmt/components/kubefirst/console-arm.yaml
@@ -9,7 +9,7 @@ spec:
   project: default
   source:
     repoURL: https://charts.kubefirst.com
-    targetRevision: 2.5.0-rc11
+    targetRevision: 2.5.0-rc12
     chart: kubefirst
     helm:
       values: |-

--- a/k3d-gitlab/cluster-types/mgmt/components/kubefirst/console-arm.yaml
+++ b/k3d-gitlab/cluster-types/mgmt/components/kubefirst/console-arm.yaml
@@ -9,7 +9,7 @@ spec:
   project: default
   source:
     repoURL: https://charts.kubefirst.com
-    targetRevision: 2.5.0-rc6
+    targetRevision: 2.5.0-rc7
     chart: kubefirst
     helm:
       values: |-

--- a/k3d-gitlab/cluster-types/mgmt/components/kubefirst/console-arm.yaml
+++ b/k3d-gitlab/cluster-types/mgmt/components/kubefirst/console-arm.yaml
@@ -9,7 +9,7 @@ spec:
   project: default
   source:
     repoURL: https://charts.kubefirst.com
-    targetRevision: 2.5.0-rc8
+    targetRevision: 2.5.0-rc9
     chart: kubefirst
     helm:
       values: |-

--- a/k3d-gitlab/cluster-types/mgmt/components/kubefirst/console-arm.yaml
+++ b/k3d-gitlab/cluster-types/mgmt/components/kubefirst/console-arm.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   project: default
   source:
-    repoURL: https://charts.kubefirst.com
+    repoURL: https://charts.konstruct.io
     targetRevision: 2.5.0-rc13
     chart: kubefirst
     helm:

--- a/k3d-gitlab/cluster-types/mgmt/components/kubefirst/console-arm.yaml
+++ b/k3d-gitlab/cluster-types/mgmt/components/kubefirst/console-arm.yaml
@@ -9,7 +9,7 @@ spec:
   project: default
   source:
     repoURL: https://charts.kubefirst.com
-    targetRevision: 2.4.17
+    targetRevision: 2.5.0-rc5
     chart: kubefirst
     helm:
       values: |-

--- a/k3d-gitlab/cluster-types/mgmt/components/kubefirst/console-arm.yaml
+++ b/k3d-gitlab/cluster-types/mgmt/components/kubefirst/console-arm.yaml
@@ -9,7 +9,7 @@ spec:
   project: default
   source:
     repoURL: https://charts.kubefirst.com
-    targetRevision: 2.5.0-rc12
+    targetRevision: 2.5.0-rc13
     chart: kubefirst
     helm:
       values: |-

--- a/k3d-gitlab/cluster-types/mgmt/components/kubefirst/console-arm.yaml
+++ b/k3d-gitlab/cluster-types/mgmt/components/kubefirst/console-arm.yaml
@@ -9,7 +9,7 @@ spec:
   project: default
   source:
     repoURL: https://charts.kubefirst.com
-    targetRevision: 2.5.0-rc9
+    targetRevision: 2.5.0-rc10
     chart: kubefirst
     helm:
       values: |-

--- a/k3d-gitlab/cluster-types/mgmt/components/kubefirst/console-arm.yaml
+++ b/k3d-gitlab/cluster-types/mgmt/components/kubefirst/console-arm.yaml
@@ -9,7 +9,7 @@ spec:
   project: default
   source:
     repoURL: https://charts.kubefirst.com
-    targetRevision: 2.5.0-rc5
+    targetRevision: 2.5.0-rc6
     chart: kubefirst
     helm:
       values: |-

--- a/k3d-gitlab/cluster-types/mgmt/components/kubefirst/console-arm.yaml
+++ b/k3d-gitlab/cluster-types/mgmt/components/kubefirst/console-arm.yaml
@@ -9,7 +9,7 @@ spec:
   project: default
   source:
     repoURL: https://charts.kubefirst.com
-    targetRevision: 2.5.0-rc10
+    targetRevision: 2.5.0-rc11
     chart: kubefirst
     helm:
       values: |-

--- a/k3d-gitlab/cluster-types/mgmt/components/kubefirst/console.yaml
+++ b/k3d-gitlab/cluster-types/mgmt/components/kubefirst/console.yaml
@@ -9,7 +9,7 @@ spec:
   project: default
   source:
     repoURL: https://charts.kubefirst.com
-    targetRevision: 2.5.0-rc7
+    targetRevision: 2.5.0-rc8
     chart: kubefirst
     helm:
       values: |-

--- a/k3d-gitlab/cluster-types/mgmt/components/kubefirst/console.yaml
+++ b/k3d-gitlab/cluster-types/mgmt/components/kubefirst/console.yaml
@@ -9,7 +9,7 @@ spec:
   project: default
   source:
     repoURL: https://charts.kubefirst.com
-    targetRevision: 2.5.0-rc11
+    targetRevision: 2.5.0-rc12
     chart: kubefirst
     helm:
       values: |-

--- a/k3d-gitlab/cluster-types/mgmt/components/kubefirst/console.yaml
+++ b/k3d-gitlab/cluster-types/mgmt/components/kubefirst/console.yaml
@@ -9,7 +9,7 @@ spec:
   project: default
   source:
     repoURL: https://charts.kubefirst.com
-    targetRevision: 2.5.0-rc6
+    targetRevision: 2.5.0-rc7
     chart: kubefirst
     helm:
       values: |-

--- a/k3d-gitlab/cluster-types/mgmt/components/kubefirst/console.yaml
+++ b/k3d-gitlab/cluster-types/mgmt/components/kubefirst/console.yaml
@@ -9,7 +9,7 @@ spec:
   project: default
   source:
     repoURL: https://charts.kubefirst.com
-    targetRevision: 2.5.0-rc8
+    targetRevision: 2.5.0-rc9
     chart: kubefirst
     helm:
       values: |-

--- a/k3d-gitlab/cluster-types/mgmt/components/kubefirst/console.yaml
+++ b/k3d-gitlab/cluster-types/mgmt/components/kubefirst/console.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   project: default
   source:
-    repoURL: https://charts.kubefirst.com
+    repoURL: https://charts.konstruct.io
     targetRevision: 2.5.0-rc13
     chart: kubefirst
     helm:

--- a/k3d-gitlab/cluster-types/mgmt/components/kubefirst/console.yaml
+++ b/k3d-gitlab/cluster-types/mgmt/components/kubefirst/console.yaml
@@ -9,7 +9,7 @@ spec:
   project: default
   source:
     repoURL: https://charts.kubefirst.com
-    targetRevision: 2.4.17
+    targetRevision: 2.5.0-rc5
     chart: kubefirst
     helm:
       values: |-

--- a/k3d-gitlab/cluster-types/mgmt/components/kubefirst/console.yaml
+++ b/k3d-gitlab/cluster-types/mgmt/components/kubefirst/console.yaml
@@ -9,7 +9,7 @@ spec:
   project: default
   source:
     repoURL: https://charts.kubefirst.com
-    targetRevision: 2.5.0-rc12
+    targetRevision: 2.5.0-rc13
     chart: kubefirst
     helm:
       values: |-

--- a/k3d-gitlab/cluster-types/mgmt/components/kubefirst/console.yaml
+++ b/k3d-gitlab/cluster-types/mgmt/components/kubefirst/console.yaml
@@ -9,7 +9,7 @@ spec:
   project: default
   source:
     repoURL: https://charts.kubefirst.com
-    targetRevision: 2.5.0-rc9
+    targetRevision: 2.5.0-rc10
     chart: kubefirst
     helm:
       values: |-

--- a/k3d-gitlab/cluster-types/mgmt/components/kubefirst/console.yaml
+++ b/k3d-gitlab/cluster-types/mgmt/components/kubefirst/console.yaml
@@ -9,7 +9,7 @@ spec:
   project: default
   source:
     repoURL: https://charts.kubefirst.com
-    targetRevision: 2.5.0-rc5
+    targetRevision: 2.5.0-rc6
     chart: kubefirst
     helm:
       values: |-

--- a/k3d-gitlab/cluster-types/mgmt/components/kubefirst/console.yaml
+++ b/k3d-gitlab/cluster-types/mgmt/components/kubefirst/console.yaml
@@ -9,7 +9,7 @@ spec:
   project: default
   source:
     repoURL: https://charts.kubefirst.com
-    targetRevision: 2.5.0-rc10
+    targetRevision: 2.5.0-rc11
     chart: kubefirst
     helm:
       values: |-

--- a/k3s-github/templates/mgmt/components/argocd/kustomization.yaml
+++ b/k3s-github/templates/mgmt/components/argocd/kustomization.yaml
@@ -5,7 +5,7 @@ namespace: argocd
 # To upgrade ArgoCD, increment the version here
 # https://github.com/argoproj/argo-cd/tags
 resources:
-  - github.com:kubefirst/manifests.git/argocd/cloud?ref=main
+  - github.com:konstructio/manifests.git/argocd/cloud?ref=v1.1.0
   - argocd-ui-ingress.yaml
   - externalsecrets.yaml
   - argocd-oidc-restart-job.yaml

--- a/k3s-github/templates/mgmt/components/kubefirst/console.yaml
+++ b/k3s-github/templates/mgmt/components/kubefirst/console.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   project: default
   source:
-    repoURL: https://charts.kubefirst.com
+    repoURL: https://charts.konstruct.io
     targetRevision: 2.4.14
     chart: kubefirst
     helm:

--- a/k3s-gitlab/templates/mgmt/components/argocd/kustomization.yaml
+++ b/k3s-gitlab/templates/mgmt/components/argocd/kustomization.yaml
@@ -5,7 +5,7 @@ namespace: argocd
 # To upgrade ArgoCD, increment the version here
 # https://github.com/argoproj/argo-cd/tags
 resources:
-  - github.com:kubefirst/manifests.git/argocd/cloud?ref=main
+  - github.com:konstructio/manifests.git/argocd/cloud?ref=v1.1.0
   - argocd-ui-ingress.yaml
   - externalsecrets.yaml
   - argocd-oidc-restart-job.yaml

--- a/k3s-gitlab/templates/mgmt/components/kubefirst/console.yaml
+++ b/k3s-gitlab/templates/mgmt/components/kubefirst/console.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   project: default
   source:
-    repoURL: https://charts.kubefirst.com
+    repoURL: https://charts.konstruct.io
     targetRevision: 2.4.14
     chart: kubefirst
     helm:

--- a/vultr-github/templates/mgmt/components/kubefirst/console.yaml
+++ b/vultr-github/templates/mgmt/components/kubefirst/console.yaml
@@ -9,7 +9,7 @@ spec:
   project: default
   source:
     repoURL: https://charts.kubefirst.com
-    targetRevision: 2.5.0-rc7
+    targetRevision: 2.5.0-rc8
     chart: kubefirst
     helm:
       values: |-

--- a/vultr-github/templates/mgmt/components/kubefirst/console.yaml
+++ b/vultr-github/templates/mgmt/components/kubefirst/console.yaml
@@ -9,7 +9,7 @@ spec:
   project: default
   source:
     repoURL: https://charts.kubefirst.com
-    targetRevision: 2.5.0-rc11
+    targetRevision: 2.5.0-rc12
     chart: kubefirst
     helm:
       values: |-

--- a/vultr-github/templates/mgmt/components/kubefirst/console.yaml
+++ b/vultr-github/templates/mgmt/components/kubefirst/console.yaml
@@ -9,7 +9,7 @@ spec:
   project: default
   source:
     repoURL: https://charts.kubefirst.com
-    targetRevision: 2.5.0-rc6
+    targetRevision: 2.5.0-rc7
     chart: kubefirst
     helm:
       values: |-

--- a/vultr-github/templates/mgmt/components/kubefirst/console.yaml
+++ b/vultr-github/templates/mgmt/components/kubefirst/console.yaml
@@ -9,7 +9,7 @@ spec:
   project: default
   source:
     repoURL: https://charts.kubefirst.com
-    targetRevision: 2.5.0-rc8
+    targetRevision: 2.5.0-rc9
     chart: kubefirst
     helm:
       values: |-

--- a/vultr-github/templates/mgmt/components/kubefirst/console.yaml
+++ b/vultr-github/templates/mgmt/components/kubefirst/console.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   project: default
   source:
-    repoURL: https://charts.kubefirst.com
+    repoURL: https://charts.konstruct.io
     targetRevision: 2.5.0-rc13
     chart: kubefirst
     helm:

--- a/vultr-github/templates/mgmt/components/kubefirst/console.yaml
+++ b/vultr-github/templates/mgmt/components/kubefirst/console.yaml
@@ -9,7 +9,7 @@ spec:
   project: default
   source:
     repoURL: https://charts.kubefirst.com
-    targetRevision: 2.4.17
+    targetRevision: 2.5.0-rc5
     chart: kubefirst
     helm:
       values: |-

--- a/vultr-github/templates/mgmt/components/kubefirst/console.yaml
+++ b/vultr-github/templates/mgmt/components/kubefirst/console.yaml
@@ -9,7 +9,7 @@ spec:
   project: default
   source:
     repoURL: https://charts.kubefirst.com
-    targetRevision: 2.5.0-rc12
+    targetRevision: 2.5.0-rc13
     chart: kubefirst
     helm:
       values: |-

--- a/vultr-github/templates/mgmt/components/kubefirst/console.yaml
+++ b/vultr-github/templates/mgmt/components/kubefirst/console.yaml
@@ -9,7 +9,7 @@ spec:
   project: default
   source:
     repoURL: https://charts.kubefirst.com
-    targetRevision: 2.5.0-rc9
+    targetRevision: 2.5.0-rc10
     chart: kubefirst
     helm:
       values: |-

--- a/vultr-github/templates/mgmt/components/kubefirst/console.yaml
+++ b/vultr-github/templates/mgmt/components/kubefirst/console.yaml
@@ -9,7 +9,7 @@ spec:
   project: default
   source:
     repoURL: https://charts.kubefirst.com
-    targetRevision: 2.5.0-rc5
+    targetRevision: 2.5.0-rc6
     chart: kubefirst
     helm:
       values: |-

--- a/vultr-github/templates/mgmt/components/kubefirst/console.yaml
+++ b/vultr-github/templates/mgmt/components/kubefirst/console.yaml
@@ -9,7 +9,7 @@ spec:
   project: default
   source:
     repoURL: https://charts.kubefirst.com
-    targetRevision: 2.5.0-rc10
+    targetRevision: 2.5.0-rc11
     chart: kubefirst
     helm:
       values: |-

--- a/vultr-gitlab/templates/mgmt/components/kubefirst/console.yaml
+++ b/vultr-gitlab/templates/mgmt/components/kubefirst/console.yaml
@@ -9,7 +9,7 @@ spec:
   project: default
   source:
     repoURL: https://charts.kubefirst.com
-    targetRevision: 2.5.0-rc7
+    targetRevision: 2.5.0-rc8
     chart: kubefirst
     helm:
       values: |-

--- a/vultr-gitlab/templates/mgmt/components/kubefirst/console.yaml
+++ b/vultr-gitlab/templates/mgmt/components/kubefirst/console.yaml
@@ -9,7 +9,7 @@ spec:
   project: default
   source:
     repoURL: https://charts.kubefirst.com
-    targetRevision: 2.5.0-rc11
+    targetRevision: 2.5.0-rc12
     chart: kubefirst
     helm:
       values: |-

--- a/vultr-gitlab/templates/mgmt/components/kubefirst/console.yaml
+++ b/vultr-gitlab/templates/mgmt/components/kubefirst/console.yaml
@@ -9,7 +9,7 @@ spec:
   project: default
   source:
     repoURL: https://charts.kubefirst.com
-    targetRevision: 2.5.0-rc6
+    targetRevision: 2.5.0-rc7
     chart: kubefirst
     helm:
       values: |-

--- a/vultr-gitlab/templates/mgmt/components/kubefirst/console.yaml
+++ b/vultr-gitlab/templates/mgmt/components/kubefirst/console.yaml
@@ -9,7 +9,7 @@ spec:
   project: default
   source:
     repoURL: https://charts.kubefirst.com
-    targetRevision: 2.5.0-rc8
+    targetRevision: 2.5.0-rc9
     chart: kubefirst
     helm:
       values: |-

--- a/vultr-gitlab/templates/mgmt/components/kubefirst/console.yaml
+++ b/vultr-gitlab/templates/mgmt/components/kubefirst/console.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   project: default
   source:
-    repoURL: https://charts.kubefirst.com
+    repoURL: https://charts.konstruct.io
     targetRevision: 2.5.0-rc13
     chart: kubefirst
     helm:

--- a/vultr-gitlab/templates/mgmt/components/kubefirst/console.yaml
+++ b/vultr-gitlab/templates/mgmt/components/kubefirst/console.yaml
@@ -9,7 +9,7 @@ spec:
   project: default
   source:
     repoURL: https://charts.kubefirst.com
-    targetRevision: 2.4.17
+    targetRevision: 2.5.0-rc5
     chart: kubefirst
     helm:
       values: |-

--- a/vultr-gitlab/templates/mgmt/components/kubefirst/console.yaml
+++ b/vultr-gitlab/templates/mgmt/components/kubefirst/console.yaml
@@ -9,7 +9,7 @@ spec:
   project: default
   source:
     repoURL: https://charts.kubefirst.com
-    targetRevision: 2.5.0-rc12
+    targetRevision: 2.5.0-rc13
     chart: kubefirst
     helm:
       values: |-

--- a/vultr-gitlab/templates/mgmt/components/kubefirst/console.yaml
+++ b/vultr-gitlab/templates/mgmt/components/kubefirst/console.yaml
@@ -9,7 +9,7 @@ spec:
   project: default
   source:
     repoURL: https://charts.kubefirst.com
-    targetRevision: 2.5.0-rc9
+    targetRevision: 2.5.0-rc10
     chart: kubefirst
     helm:
       values: |-

--- a/vultr-gitlab/templates/mgmt/components/kubefirst/console.yaml
+++ b/vultr-gitlab/templates/mgmt/components/kubefirst/console.yaml
@@ -9,7 +9,7 @@ spec:
   project: default
   source:
     repoURL: https://charts.kubefirst.com
-    targetRevision: 2.5.0-rc5
+    targetRevision: 2.5.0-rc6
     chart: kubefirst
     helm:
       values: |-

--- a/vultr-gitlab/templates/mgmt/components/kubefirst/console.yaml
+++ b/vultr-gitlab/templates/mgmt/components/kubefirst/console.yaml
@@ -9,7 +9,7 @@ spec:
   project: default
   source:
     repoURL: https://charts.kubefirst.com
-    targetRevision: 2.5.0-rc10
+    targetRevision: 2.5.0-rc11
     chart: kubefirst
     helm:
       values: |-


### PR DESCRIPTION
## Description
changed kubefirst charts reference to Konstruct

## Testing 
use the kubefirst binary and add the flag "--gitops-template-branch k3d-upgrade"
