### PR TITLE
feat:upgrade vault and crossplane version

### DIFF
--- a/akamai-github/templates/mgmt/components/crossplane/crossplane-system/crossplane-system.yaml
+++ b/akamai-github/templates/mgmt/components/crossplane/crossplane-system/crossplane-system.yaml
@@ -15,7 +15,7 @@ spec:
   source:
     repoURL: https://charts.crossplane.io/stable
     chart: crossplane
-    targetRevision: 1.12.2
+    targetRevision: 1.17.0
   syncPolicy:
     automated:
       prune: true

--- a/akamai-github/templates/mgmt/components/vault/application.yaml
+++ b/akamai-github/templates/mgmt/components/vault/application.yaml
@@ -9,7 +9,7 @@ spec:
   project: default
   source:
     repoURL: https://helm.releases.hashicorp.com
-    targetRevision: 0.22.0
+    targetRevision: 0.28.1
     helm:
       values: |-
         server:

--- a/akamai-github/templates/mgmt/components/vault/application.yaml
+++ b/akamai-github/templates/mgmt/components/vault/application.yaml
@@ -9,7 +9,7 @@ spec:
   project: default
   source:
     repoURL: https://helm.releases.hashicorp.com
-    targetRevision: 0.28.1
+    targetRevision: 0.25.0
     helm:
       values: |-
         server:

--- a/aws-github/templates/mgmt/components/crossplane/crossplane-system/crossplane-system.yaml
+++ b/aws-github/templates/mgmt/components/crossplane/crossplane-system/crossplane-system.yaml
@@ -15,7 +15,7 @@ spec:
   source:
     repoURL: https://charts.crossplane.io/stable
     chart: crossplane
-    targetRevision: 1.12.2
+    targetRevision: 1.17.0
   syncPolicy:
     automated:
       prune: true

--- a/aws-github/templates/mgmt/components/vault/application.yaml
+++ b/aws-github/templates/mgmt/components/vault/application.yaml
@@ -9,7 +9,7 @@ spec:
   project: default
   source:
     repoURL: https://helm.releases.hashicorp.com
-    targetRevision: 0.22.0
+    targetRevision: 0.28.1
     helm:
       parameters:
         - name: server.route.host

--- a/aws-github/templates/mgmt/components/vault/application.yaml
+++ b/aws-github/templates/mgmt/components/vault/application.yaml
@@ -9,7 +9,7 @@ spec:
   project: default
   source:
     repoURL: https://helm.releases.hashicorp.com
-    targetRevision: 0.28.1
+    targetRevision: 0.25.0
     helm:
       parameters:
         - name: server.route.host

--- a/aws-gitlab/templates/mgmt/components/crossplane/crossplane-system/crossplane-system.yaml
+++ b/aws-gitlab/templates/mgmt/components/crossplane/crossplane-system/crossplane-system.yaml
@@ -15,7 +15,7 @@ spec:
   source:
     repoURL: https://charts.crossplane.io/stable
     chart: crossplane
-    targetRevision: 1.12.2
+    targetRevision: 1.17.0
   syncPolicy:
     automated:
       prune: true

--- a/aws-gitlab/templates/mgmt/components/vault/application.yaml
+++ b/aws-gitlab/templates/mgmt/components/vault/application.yaml
@@ -9,7 +9,7 @@ spec:
   project: default
   source:
     repoURL: https://helm.releases.hashicorp.com
-    targetRevision: 0.22.0
+    targetRevision: 0.28.1
     helm:
       parameters:
         - name: server.route.host

--- a/aws-gitlab/templates/mgmt/components/vault/application.yaml
+++ b/aws-gitlab/templates/mgmt/components/vault/application.yaml
@@ -9,7 +9,7 @@ spec:
   project: default
   source:
     repoURL: https://helm.releases.hashicorp.com
-    targetRevision: 0.28.1
+    targetRevision: 0.25.0
     helm:
       parameters:
         - name: server.route.host

--- a/civo-github/templates/mgmt/components/crossplane/crossplane-system/crossplane-system.yaml
+++ b/civo-github/templates/mgmt/components/crossplane/crossplane-system/crossplane-system.yaml
@@ -15,7 +15,7 @@ spec:
   source:
     repoURL: https://charts.crossplane.io/stable
     chart: crossplane
-    targetRevision: 1.12.2
+    targetRevision: 1.17.0
   syncPolicy:
     automated:
       prune: true

--- a/civo-github/templates/mgmt/components/vault/application.yaml
+++ b/civo-github/templates/mgmt/components/vault/application.yaml
@@ -9,7 +9,7 @@ spec:
   project: default
   source:
     repoURL: https://helm.releases.hashicorp.com
-    targetRevision: 0.22.0
+    targetRevision: 0.28.1
     helm:
       values: |-
         server:

--- a/civo-github/templates/mgmt/components/vault/application.yaml
+++ b/civo-github/templates/mgmt/components/vault/application.yaml
@@ -9,7 +9,7 @@ spec:
   project: default
   source:
     repoURL: https://helm.releases.hashicorp.com
-    targetRevision: 0.28.1
+    targetRevision: 0.25.0
     helm:
       values: |-
         server:

--- a/civo-gitlab/templates/mgmt/components/crossplane/crossplane-system/crossplane-system.yaml
+++ b/civo-gitlab/templates/mgmt/components/crossplane/crossplane-system/crossplane-system.yaml
@@ -15,7 +15,7 @@ spec:
   source:
     repoURL: https://charts.crossplane.io/stable
     chart: crossplane
-    targetRevision: 1.12.2
+    targetRevision: 1.17.0
   syncPolicy:
     automated:
       prune: true

--- a/civo-gitlab/templates/mgmt/components/vault/application.yaml
+++ b/civo-gitlab/templates/mgmt/components/vault/application.yaml
@@ -9,7 +9,7 @@ spec:
   project: default
   source:
     repoURL: https://helm.releases.hashicorp.com
-    targetRevision: 0.22.0
+    targetRevision: 0.28.1
     helm:
       values: |-
         server:

--- a/civo-gitlab/templates/mgmt/components/vault/application.yaml
+++ b/civo-gitlab/templates/mgmt/components/vault/application.yaml
@@ -9,7 +9,7 @@ spec:
   project: default
   source:
     repoURL: https://helm.releases.hashicorp.com
-    targetRevision: 0.28.1
+    targetRevision: 0.25.0
     helm:
       values: |-
         server:

--- a/digitalocean-github/templates/mgmt/components/crossplane/crossplane-system/crossplane-system.yaml
+++ b/digitalocean-github/templates/mgmt/components/crossplane/crossplane-system/crossplane-system.yaml
@@ -15,7 +15,7 @@ spec:
   source:
     repoURL: https://charts.crossplane.io/stable
     chart: crossplane
-    targetRevision: 1.12.2
+    targetRevision: 1.17.0
   syncPolicy:
     automated:
       prune: true

--- a/digitalocean-github/templates/mgmt/components/vault/application.yaml
+++ b/digitalocean-github/templates/mgmt/components/vault/application.yaml
@@ -9,7 +9,7 @@ spec:
   project: default
   source:
     repoURL: https://helm.releases.hashicorp.com
-    targetRevision: 0.22.0
+    targetRevision: 0.28.1
     helm:
       values: |-
         server:

--- a/digitalocean-github/templates/mgmt/components/vault/application.yaml
+++ b/digitalocean-github/templates/mgmt/components/vault/application.yaml
@@ -9,7 +9,7 @@ spec:
   project: default
   source:
     repoURL: https://helm.releases.hashicorp.com
-    targetRevision: 0.28.1
+    targetRevision: 0.25.0
     helm:
       values: |-
         server:

--- a/digitalocean-gitlab/templates/mgmt/components/crossplane/crossplane-system/crossplane-system.yaml
+++ b/digitalocean-gitlab/templates/mgmt/components/crossplane/crossplane-system/crossplane-system.yaml
@@ -15,7 +15,7 @@ spec:
   source:
     repoURL: https://charts.crossplane.io/stable
     chart: crossplane
-    targetRevision: 1.12.2
+    targetRevision: 1.17.0
   syncPolicy:
     automated:
       prune: true

--- a/digitalocean-gitlab/templates/mgmt/components/vault/application.yaml
+++ b/digitalocean-gitlab/templates/mgmt/components/vault/application.yaml
@@ -9,7 +9,7 @@ spec:
   project: default
   source:
     repoURL: https://helm.releases.hashicorp.com
-    targetRevision: 0.22.0
+    targetRevision: 0.28.1
     helm:
       values: |-
         server:

--- a/digitalocean-gitlab/templates/mgmt/components/vault/application.yaml
+++ b/digitalocean-gitlab/templates/mgmt/components/vault/application.yaml
@@ -9,7 +9,7 @@ spec:
   project: default
   source:
     repoURL: https://helm.releases.hashicorp.com
-    targetRevision: 0.28.1
+    targetRevision: 0.25.0
     helm:
       values: |-
         server:

--- a/google-github/templates/mgmt/components/crossplane/crossplane-system/crossplane-system.yaml
+++ b/google-github/templates/mgmt/components/crossplane/crossplane-system/crossplane-system.yaml
@@ -15,7 +15,7 @@ spec:
   source:
     repoURL: https://charts.crossplane.io/stable
     chart: crossplane
-    targetRevision: 1.12.2
+    targetRevision: 1.17.0
   syncPolicy:
     automated:
       prune: true

--- a/google-github/templates/mgmt/components/vault/application.yaml
+++ b/google-github/templates/mgmt/components/vault/application.yaml
@@ -9,7 +9,7 @@ spec:
   project: default
   source:
     repoURL: https://helm.releases.hashicorp.com
-    targetRevision: 0.22.0
+    targetRevision: 0.28.1
     helm:
       parameters:
       - name: server.route.host

--- a/google-github/templates/mgmt/components/vault/application.yaml
+++ b/google-github/templates/mgmt/components/vault/application.yaml
@@ -9,7 +9,7 @@ spec:
   project: default
   source:
     repoURL: https://helm.releases.hashicorp.com
-    targetRevision: 0.28.1
+    targetRevision: 0.25.0
     helm:
       parameters:
       - name: server.route.host

--- a/google-gitlab/templates/mgmt/components/crossplane/crossplane-system/crossplane-system.yaml
+++ b/google-gitlab/templates/mgmt/components/crossplane/crossplane-system/crossplane-system.yaml
@@ -15,7 +15,7 @@ spec:
   source:
     repoURL: https://charts.crossplane.io/stable
     chart: crossplane
-    targetRevision: 1.12.2
+    targetRevision: 1.17.0
   syncPolicy:
     automated:
       prune: true

--- a/google-gitlab/templates/mgmt/components/vault/application.yaml
+++ b/google-gitlab/templates/mgmt/components/vault/application.yaml
@@ -9,7 +9,7 @@ spec:
   project: default
   source:
     repoURL: https://helm.releases.hashicorp.com
-    targetRevision: 0.22.0
+    targetRevision: 0.28.1
     helm:
       parameters:
       - name: server.route.host

--- a/google-gitlab/templates/mgmt/components/vault/application.yaml
+++ b/google-gitlab/templates/mgmt/components/vault/application.yaml
@@ -9,7 +9,7 @@ spec:
   project: default
   source:
     repoURL: https://helm.releases.hashicorp.com
-    targetRevision: 0.28.1
+    targetRevision: 0.25.0
     helm:
       parameters:
       - name: server.route.host

--- a/k3d-github/cluster-types/mgmt/components/crossplane/crossplane-system/crossplane-system.yaml
+++ b/k3d-github/cluster-types/mgmt/components/crossplane/crossplane-system/crossplane-system.yaml
@@ -15,7 +15,7 @@ spec:
   source:
     repoURL: https://charts.crossplane.io/stable
     chart: crossplane
-    targetRevision: 1.12.2
+    targetRevision: 1.17.0
   syncPolicy:
     automated:
       prune: true

--- a/k3d-github/cluster-types/mgmt/components/vault/application.yaml
+++ b/k3d-github/cluster-types/mgmt/components/vault/application.yaml
@@ -9,7 +9,7 @@ spec:
   project: default
   source:
     repoURL: 'https://helm.releases.hashicorp.com'
-    targetRevision: 0.22.0
+    targetRevision: 0.28.1
     helm:
       parameters:
         - name: 'server.ingress.hosts[0].host'

--- a/k3d-github/cluster-types/mgmt/components/vault/application.yaml
+++ b/k3d-github/cluster-types/mgmt/components/vault/application.yaml
@@ -9,7 +9,7 @@ spec:
   project: default
   source:
     repoURL: 'https://helm.releases.hashicorp.com'
-    targetRevision: 0.28.1
+    targetRevision: 0.25.0
     helm:
       parameters:
         - name: 'server.ingress.hosts[0].host'

--- a/k3d-gitlab/cluster-types/mgmt/components/crossplane/crossplane-system/crossplane-system.yaml
+++ b/k3d-gitlab/cluster-types/mgmt/components/crossplane/crossplane-system/crossplane-system.yaml
@@ -15,7 +15,7 @@ spec:
   source:
     repoURL: https://charts.crossplane.io/stable
     chart: crossplane
-    targetRevision: 1.12.2
+    targetRevision: 1.17.0
   syncPolicy:
     automated:
       prune: true

--- a/k3d-gitlab/cluster-types/mgmt/components/vault/application.yaml
+++ b/k3d-gitlab/cluster-types/mgmt/components/vault/application.yaml
@@ -9,7 +9,7 @@ spec:
   project: default
   source:
     repoURL: 'https://helm.releases.hashicorp.com'
-    targetRevision: 0.22.0
+    targetRevision: 0.28.1
     helm:
       parameters:
         - name: 'server.ingress.hosts[0].host'

--- a/k3d-gitlab/cluster-types/mgmt/components/vault/application.yaml
+++ b/k3d-gitlab/cluster-types/mgmt/components/vault/application.yaml
@@ -9,7 +9,7 @@ spec:
   project: default
   source:
     repoURL: 'https://helm.releases.hashicorp.com'
-    targetRevision: 0.28.1
+    targetRevision: 0.25.0
     helm:
       parameters:
         - name: 'server.ingress.hosts[0].host'

--- a/k3s-github/templates/mgmt/components/crossplane/crossplane-system/crossplane-system.yaml
+++ b/k3s-github/templates/mgmt/components/crossplane/crossplane-system/crossplane-system.yaml
@@ -15,7 +15,7 @@ spec:
   source:
     repoURL: https://charts.crossplane.io/stable
     chart: crossplane
-    targetRevision: 1.12.2
+    targetRevision: 1.17.0
   syncPolicy:
     automated:
       prune: true

--- a/k3s-github/templates/mgmt/components/vault/application.yaml
+++ b/k3s-github/templates/mgmt/components/vault/application.yaml
@@ -9,7 +9,7 @@ spec:
   project: default
   source:
     repoURL: https://helm.releases.hashicorp.com
-    targetRevision: 0.22.0
+    targetRevision: 0.28.1
     helm:
       values: |-
         server:

--- a/k3s-github/templates/mgmt/components/vault/application.yaml
+++ b/k3s-github/templates/mgmt/components/vault/application.yaml
@@ -9,7 +9,7 @@ spec:
   project: default
   source:
     repoURL: https://helm.releases.hashicorp.com
-    targetRevision: 0.28.1
+    targetRevision: 0.25.0
     helm:
       values: |-
         server:

--- a/k3s-gitlab/templates/mgmt/components/crossplane/crossplane-system/crossplane-system.yaml
+++ b/k3s-gitlab/templates/mgmt/components/crossplane/crossplane-system/crossplane-system.yaml
@@ -15,7 +15,7 @@ spec:
   source:
     repoURL: https://charts.crossplane.io/stable
     chart: crossplane
-    targetRevision: 1.12.2
+    targetRevision: 1.17.0
   syncPolicy:
     automated:
       prune: true

--- a/k3s-gitlab/templates/mgmt/components/vault/application.yaml
+++ b/k3s-gitlab/templates/mgmt/components/vault/application.yaml
@@ -9,7 +9,7 @@ spec:
   project: default
   source:
     repoURL: https://helm.releases.hashicorp.com
-    targetRevision: 0.22.0
+    targetRevision: 0.28.1
     helm:
       values: |-
         server:

--- a/k3s-gitlab/templates/mgmt/components/vault/application.yaml
+++ b/k3s-gitlab/templates/mgmt/components/vault/application.yaml
@@ -9,7 +9,7 @@ spec:
   project: default
   source:
     repoURL: https://helm.releases.hashicorp.com
-    targetRevision: 0.28.1
+    targetRevision: 0.25.0
     helm:
       values: |-
         server:

--- a/vultr-github/templates/mgmt/components/crossplane/crossplane-system/crossplane-system.yaml
+++ b/vultr-github/templates/mgmt/components/crossplane/crossplane-system/crossplane-system.yaml
@@ -15,7 +15,7 @@ spec:
   source:
     repoURL: https://charts.crossplane.io/stable
     chart: crossplane
-    targetRevision: 1.12.2
+    targetRevision: 1.17.0
   syncPolicy:
     automated:
       prune: true

--- a/vultr-github/templates/mgmt/components/vault/application.yaml
+++ b/vultr-github/templates/mgmt/components/vault/application.yaml
@@ -9,7 +9,7 @@ spec:
   project: default
   source:
     repoURL: https://helm.releases.hashicorp.com
-    targetRevision: 0.22.0
+    targetRevision: 0.28.1
     helm:
       values: |-
         server:

--- a/vultr-github/templates/mgmt/components/vault/application.yaml
+++ b/vultr-github/templates/mgmt/components/vault/application.yaml
@@ -9,7 +9,7 @@ spec:
   project: default
   source:
     repoURL: https://helm.releases.hashicorp.com
-    targetRevision: 0.28.1
+    targetRevision: 0.25.0
     helm:
       values: |-
         server:

--- a/vultr-gitlab/templates/mgmt/components/crossplane/crossplane-system/crossplane-system.yaml
+++ b/vultr-gitlab/templates/mgmt/components/crossplane/crossplane-system/crossplane-system.yaml
@@ -15,7 +15,7 @@ spec:
   source:
     repoURL: https://charts.crossplane.io/stable
     chart: crossplane
-    targetRevision: 1.12.2
+    targetRevision: 1.17.0
   syncPolicy:
     automated:
       prune: true

--- a/vultr-gitlab/templates/mgmt/components/vault/application.yaml
+++ b/vultr-gitlab/templates/mgmt/components/vault/application.yaml
@@ -9,7 +9,7 @@ spec:
   project: default
   source:
     repoURL: https://helm.releases.hashicorp.com
-    targetRevision: 0.22.0
+    targetRevision: 0.28.1
     helm:
       values: |-
         server:

--- a/vultr-gitlab/templates/mgmt/components/vault/application.yaml
+++ b/vultr-gitlab/templates/mgmt/components/vault/application.yaml
@@ -9,7 +9,7 @@ spec:
   project: default
   source:
     repoURL: https://helm.releases.hashicorp.com
-    targetRevision: 0.28.1
+    targetRevision: 0.25.0
     helm:
       values: |-
         server:


### PR DESCRIPTION
## Description
bump crossplane to 1.17.0 and vault to 0.28.1

## How to test
when provisioning a cluster,use "--gitops-template-branch vault-crossplane-upgrade" flag
