### PR TITLE
fix: correct typo in vault/secrets.tf for gitlab deployments

### DIFF
--- a/aws-gitlab/terraform/vault/secrets.tf
+++ b/aws-gitlab/terraform/vault/secrets.tf
@@ -44,7 +44,7 @@ resource "vault_generic_secret" "container_registry_auth" {
 
   data_json = jsonencode(
     {
-      auth = jsonencode({ "auths" : { "registry.gitlab.com" : { "username" : "container-registry-auth", "password" : "${var.container_registry_auth}", "email" : "kbo@example.com", "auth" : "${var.b64_docker_auth}" } } }),
+      auth = jsonencode({ "auths" : { "registry.gitlab.com" : { "username" : "container-registry-auth", "password" : "${var.container_registry_auth}", "email" : "kbot@example.com", "auth" : "${var.b64_docker_auth}" } } }),
     }
   )
 }

--- a/civo-gitlab/terraform/vault/secrets.tf
+++ b/civo-gitlab/terraform/vault/secrets.tf
@@ -22,7 +22,7 @@ resource "vault_generic_secret" "container_registry_auth" {
 
   data_json = jsonencode(
     {
-      auth = jsonencode({ "auths" : { "registry.gitlab.com" : { "username" : "container-registry-auth", "password" : "${var.container_registry_auth}", "email" : "kbo@example.com", "auth" : "${var.b64_docker_auth}" } } }),
+      auth = jsonencode({ "auths" : { "registry.gitlab.com" : { "username" : "container-registry-auth", "password" : "${var.container_registry_auth}", "email" : "kbot@example.com", "auth" : "${var.b64_docker_auth}" } } }),
     }
   )
 }

--- a/digitalocean-gitlab/terraform/vault/secrets.tf
+++ b/digitalocean-gitlab/terraform/vault/secrets.tf
@@ -38,7 +38,7 @@ resource "vault_generic_secret" "container_registry_auth" {
 
   data_json = jsonencode(
     {
-      auth = jsonencode({ "auths" : { "registry.gitlab.com" : { "username" : "container-registry-auth", "password" : "${var.container_registry_auth}", "email" : "kbo@example.com", "auth" : "${var.b64_docker_auth}" } } }),
+      auth = jsonencode({ "auths" : { "registry.gitlab.com" : { "username" : "container-registry-auth", "password" : "${var.container_registry_auth}", "email" : "kbot@example.com", "auth" : "${var.b64_docker_auth}" } } }),
     }
   )
 }

--- a/google-gitlab/terraform/vault/secrets.tf
+++ b/google-gitlab/terraform/vault/secrets.tf
@@ -34,7 +34,7 @@ resource "vault_generic_secret" "container_registry_auth" {
 
   data_json = jsonencode(
     {
-      auth = jsonencode({ "auths" : { "registry.gitlab.com" : { "username" : "container-registry-auth", "password" : "${var.container_registry_auth}", "email" : "kbo@example.com", "auth" : "${var.b64_docker_auth}" } } }),
+      auth = jsonencode({ "auths" : { "registry.gitlab.com" : { "username" : "container-registry-auth", "password" : "${var.container_registry_auth}", "email" : "kbot@example.com", "auth" : "${var.b64_docker_auth}" } } }),
     }
   )
 }

--- a/k3d-gitlab/terraform/vault/secrets.tf
+++ b/k3d-gitlab/terraform/vault/secrets.tf
@@ -46,7 +46,7 @@ resource "vault_generic_secret" "container_registry_auth" {
 
   data_json = jsonencode(
     {
-      auth = jsonencode({ "auths" : { "registry.gitlab.com" : { "username" : "container-registry-auth", "password" : "${var.container_registry_auth}", "email" : "kbo@example.com", "auth" : "${var.b64_docker_auth}" } } }),
+      auth = jsonencode({ "auths" : { "registry.gitlab.com" : { "username" : "container-registry-auth", "password" : "${var.container_registry_auth}", "email" : "kbot@example.com", "auth" : "${var.b64_docker_auth}" } } }),
     }
   )
 }

--- a/k3s-gitlab/terraform/vault/secrets.tf
+++ b/k3s-gitlab/terraform/vault/secrets.tf
@@ -66,7 +66,7 @@ resource "vault_generic_secret" "container_registry_auth" {
 
   data_json = jsonencode(
     {
-      auth = jsonencode({ "auths" : { "registry.gitlab.com" : { "username" : "container-registry-auth", "password" : "${var.container_registry_auth}", "email" : "kbo@example.com", "auth" : "${var.b64_docker_auth}" } } }),
+      auth = jsonencode({ "auths" : { "registry.gitlab.com" : { "username" : "container-registry-auth", "password" : "${var.container_registry_auth}", "email" : "kbot@example.com", "auth" : "${var.b64_docker_auth}" } } }),
     }
   )
 

--- a/vultr-gitlab/terraform/vault/secrets.tf
+++ b/vultr-gitlab/terraform/vault/secrets.tf
@@ -38,7 +38,7 @@ resource "vault_generic_secret" "container_registry_auth" {
 
   data_json = jsonencode(
     {
-      auth = jsonencode({ "auths" : { "registry.gitlab.com" : { "username" : "container-registry-auth", "password" : "${var.container_registry_auth}", "email" : "kbo@example.com", "auth" : "${var.b64_docker_auth}" } } }),
+      auth = jsonencode({ "auths" : { "registry.gitlab.com" : { "username" : "container-registry-auth", "password" : "${var.container_registry_auth}", "email" : "kbot@example.com", "auth" : "${var.b64_docker_auth}" } } }),
     }
   )
 }


### PR DESCRIPTION
## Description
I caught a small typo in the `/deploy-tokens/container-registry-auth` vault secret for all gitlab deployments. I discovered this while troubleshooting some authentication issues (although, this typo turned out to be unrelated to that). Thanks for all your work!

## Related Issue(s)
N/A

## How to test
N/A
