### PR TITLE
fix(EKS): multi-account ArgoCD access  

### DIFF
--- a/aws-github/templates/mgmt/components/argocd/argocd-cm.yaml
+++ b/aws-github/templates/mgmt/components/argocd/argocd-cm.yaml
@@ -11,3 +11,34 @@ data:
     clientSecret: $argocd-oidc-secret:clientSecret
     requestedScopes: ["openid", "groups", "user", "profile", "email"]
     requestedIDTokenClaims: {"groups": {"essential": true}}
+
+  resource.customizations: |
+    tf.upbound.io/Workspace:
+      health.lua: |
+        local hs = {}
+        if obj.status ~= nil then
+          if obj.status.conditions ~= nil then
+            local installed = false
+            local healthy = false
+            for i, condition in ipairs(obj.status.conditions) do
+              if condition.type == "Ready" then
+                installed = condition.status == "True"
+                installed_message = condition.reason
+              elseif condition.type == "Synced" then
+                healthy = condition.status == "True"
+                healthy_message = condition.reason
+              end
+            end
+            if installed and healthy then
+              hs.status = "Healthy"
+            else
+              hs.status = "Degraded"
+            end
+            hs.message = installed_message .. " " .. healthy_message
+            return hs
+          end
+        end
+        
+        hs.status = "Progressing"
+        hs.message = "Waiting for wworkspace to finish running"
+        return hs      

--- a/aws-github/templates/workload-cluster/provider-config/providerconfig.yaml
+++ b/aws-github/templates/workload-cluster/provider-config/providerconfig.yaml
@@ -35,8 +35,10 @@ spec:
       provider "aws" {
         region = "<WORKLOAD_CLUSTER_REGION>"
         allowed_account_ids = ["<WORKLOAD_CLUSTER_ACCOUNT_ID>"]
-        assume_role {
+        assume_role_with_web_identity {
+          session_name = "kubefirst-pro"
           role_arn = "<WORKLOAD_ASSUME_ROLE>"
+          web_identity_token_file = "/var/run/secrets/eks.amazonaws.com/serviceaccount/token"
         }
       }
   credentials:

--- a/aws-github/terraform/aws/modules/workload-cluster/main.tf
+++ b/aws-github/terraform/aws/modules/workload-cluster/main.tf
@@ -22,6 +22,22 @@ module "eks" {
   create_kms_key                 = false
   cluster_encryption_config      = {}
 
+  access_entries = {
+    "argocd_<AWS_ACCOUNT_ID>" = {
+      cluster_name  = "${var.cluster_name}"
+      principal_arn = "arn:aws:iam::<AWS_ACCOUNT_ID>:role/argocd-<AWS_ACCOUNT_ID>"
+      policy_associations = {
+        argocdAdminAccess = {
+          policy_arn = "arn:aws:eks::aws:cluster-access-policy/AmazonEKSClusterAdminPolicy"
+          access_scope = {
+            namespaces = []
+            type       = "cluster"
+          }
+        }
+      }
+    }
+  }
+
   cluster_addons = {
     aws-ebs-csi-driver = {
       most_recent              = true
@@ -446,11 +462,11 @@ resource "aws_iam_policy" "cluster_autoscaler" {
   name = "cluster-autoscaler-${var.cluster_name}"
   path = "/"
   policy = jsonencode({
-    "Version": "2012-10-17",
-    "Statement": [
+    "Version" : "2012-10-17",
+    "Statement" : [
       {
-        "Effect": "Allow",
-        "Action": [
+        "Effect" : "Allow",
+        "Action" : [
           "autoscaling:DescribeAutoScalingGroups",
           "autoscaling:DescribeAutoScalingInstances",
           "autoscaling:DescribeLaunchConfigurations",
@@ -463,7 +479,7 @@ resource "aws_iam_policy" "cluster_autoscaler" {
           "autoscaling:SetDesiredCapacity",
           "autoscaling:TerminateInstanceInAutoScalingGroup"
         ],
-        "Resource": ["*"]
+        "Resource" : ["*"]
       }
     ]
   })

--- a/aws-gitlab/templates/mgmt/components/argocd/argocd-cm.yaml
+++ b/aws-gitlab/templates/mgmt/components/argocd/argocd-cm.yaml
@@ -11,3 +11,34 @@ data:
     clientSecret: $argocd-oidc-secret:clientSecret
     requestedScopes: ["openid", "groups", "user", "profile", "email"]
     requestedIDTokenClaims: {"groups": {"essential": true}}
+
+  resource.customizations: |
+    tf.upbound.io/Workspace:
+      health.lua: |
+        local hs = {}
+        if obj.status ~= nil then
+          if obj.status.conditions ~= nil then
+            local installed = false
+            local healthy = false
+            for i, condition in ipairs(obj.status.conditions) do
+              if condition.type == "Ready" then
+                installed = condition.status == "True"
+                installed_message = condition.reason
+              elseif condition.type == "Synced" then
+                healthy = condition.status == "True"
+                healthy_message = condition.reason
+              end
+            end
+            if installed and healthy then
+              hs.status = "Healthy"
+            else
+              hs.status = "Degraded"
+            end
+            hs.message = installed_message .. " " .. healthy_message
+            return hs
+          end
+        end
+        
+        hs.status = "Progressing"
+        hs.message = "Waiting for wworkspace to finish running"
+        return hs      

--- a/aws-gitlab/templates/workload-cluster/provider-config/providerconfig.yaml
+++ b/aws-gitlab/templates/workload-cluster/provider-config/providerconfig.yaml
@@ -35,8 +35,10 @@ spec:
       provider "aws" {
         region = "<WORKLOAD_CLUSTER_REGION>"
         allowed_account_ids = ["<WORKLOAD_CLUSTER_ACCOUNT_ID>"]
-        assume_role {
+        assume_role_with_web_identity {
+          session_name = "kubefirst-pro"
           role_arn = "<WORKLOAD_ASSUME_ROLE>"
+          web_identity_token_file = "/var/run/secrets/eks.amazonaws.com/serviceaccount/token"
         }
       }
   credentials:

--- a/aws-gitlab/terraform/aws/modules/workload-cluster/main.tf
+++ b/aws-gitlab/terraform/aws/modules/workload-cluster/main.tf
@@ -15,7 +15,7 @@ locals {
 ################################################################################
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "19.10.0"
+  version = "~> 20.0"
 
   cluster_name                   = var.cluster_name
   cluster_version                = local.cluster_version
@@ -23,6 +23,23 @@ module "eks" {
   create_kms_key                 = false
   cluster_encryption_config      = {}
   create_iam_role                = true
+
+  access_entries = {
+    "argocd_<AWS_ACCOUNT_ID>" = {
+      cluster_name  = "${var.cluster_name}"
+      principal_arn = "arn:aws:iam::<AWS_ACCOUNT_ID>:role/argocd-<AWS_ACCOUNT_ID>"
+      policy_associations = {
+        argocdAdminAccess = {
+          policy_arn = "arn:aws:eks::aws:cluster-access-policy/AmazonEKSClusterAdminPolicy"
+          access_scope = {
+            namespaces = []
+            type       = "cluster"
+          }
+        }
+      }
+    }
+  }
+
   cluster_addons = {
     # AWS launch CoreDNS itself with their add-on https://docs.aws.amazon.com/eks/latest/userguide/managing-coredns.html
     # coredns = {
@@ -455,11 +472,11 @@ resource "aws_iam_policy" "cluster_autoscaler" {
   name = "cluster-autoscaler-${var.cluster_name}"
   path = "/"
   policy = jsonencode({
-    "Version": "2012-10-17",
-    "Statement": [
+    "Version" : "2012-10-17",
+    "Statement" : [
       {
-        "Effect": "Allow",
-        "Action": [
+        "Effect" : "Allow",
+        "Action" : [
           "autoscaling:DescribeAutoScalingGroups",
           "autoscaling:DescribeAutoScalingInstances",
           "autoscaling:DescribeLaunchConfigurations",
@@ -472,7 +489,7 @@ resource "aws_iam_policy" "cluster_autoscaler" {
           "autoscaling:SetDesiredCapacity",
           "autoscaling:TerminateInstanceInAutoScalingGroup"
         ],
-        "Resource": ["*"]
+        "Resource" : ["*"]
       }
     ]
   })


### PR DESCRIPTION
## Description
PR adds
- Add an access entry for argocd in workload account. 
- Add custom health check for `tf.upbound.io/Workspace`
- Use `assume_role_with_web_identity` feature

## Related Issue(s)

## How to test
Run the cluster.