### PR TITLE
fix: aws multi

### DIFF
--- a/akamai-github/templates/mgmt/components/argocd/kustomization.yaml
+++ b/akamai-github/templates/mgmt/components/argocd/kustomization.yaml
@@ -5,7 +5,7 @@ namespace: argocd
 # To upgrade ArgoCD, increment the version here
 # https://github.com/argoproj/argo-cd/tags
 resources:
-  - github.com:konstructio/manifests.git/argocd/cloud?ref=v1.1.0
+  - github.com:konstructio/manifests.git/argocd/cloud?ref=v1.1.1
   - argocd-ui-ingress.yaml
   - externalsecrets.yaml
   - argocd-oidc-restart-job.yaml

--- a/aws-github/templates/mgmt/components/argocd/argocd-cm.yaml
+++ b/aws-github/templates/mgmt/components/argocd/argocd-cm.yaml
@@ -10,35 +10,4 @@ data:
     clientID: $argocd-oidc-secret:clientId
     clientSecret: $argocd-oidc-secret:clientSecret
     requestedScopes: ["openid", "groups", "user", "profile", "email"]
-    requestedIDTokenClaims: {"groups": {"essential": true}}
-
-  resource.customizations: |
-    tf.upbound.io/Workspace:
-      health.lua: |
-        local hs = {}
-        if obj.status ~= nil then
-          if obj.status.conditions ~= nil then
-            local installed = false
-            local healthy = false
-            for i, condition in ipairs(obj.status.conditions) do
-              if condition.type == "Ready" then
-                installed = condition.status == "True"
-                installed_message = condition.reason
-              elseif condition.type == "Synced" then
-                healthy = condition.status == "True"
-                healthy_message = condition.reason
-              end
-            end
-            if installed and healthy then
-              hs.status = "Healthy"
-            else
-              hs.status = "Degraded"
-            end
-            hs.message = installed_message .. " " .. healthy_message
-            return hs
-          end
-        end
-        
-        hs.status = "Progressing"
-        hs.message = "Waiting for wworkspace to finish running"
-        return hs      
+    requestedIDTokenClaims: {"groups": {"essential": true}}   

--- a/aws-github/templates/mgmt/components/argocd/kustomization.yaml
+++ b/aws-github/templates/mgmt/components/argocd/kustomization.yaml
@@ -5,7 +5,7 @@ namespace: argocd
 # To upgrade ArgoCD, increment the version here
 # https://github.com/argoproj/argo-cd/tags
 resources:
-  - github.com:konstructio/manifests.git/argocd/cloud?ref=v1.1.0
+  - github.com:konstructio/manifests.git/argocd/cloud?ref=v1.1.1
   - argocd-ui-ingress.yaml
   - externalsecrets.yaml
   - argocd-oidc-restart-job.yaml

--- a/aws-github/terraform/aws/modules/workload-cluster/main.tf
+++ b/aws-github/terraform/aws/modules/workload-cluster/main.tf
@@ -25,7 +25,7 @@ module "eks" {
   access_entries = {
     "argocd_<AWS_ACCOUNT_ID>" = {
       cluster_name  = "${var.cluster_name}"
-      principal_arn = "arn:aws:iam::<AWS_ACCOUNT_ID>:role/argocd-<AWS_ACCOUNT_ID>"
+      principal_arn = "arn:aws:iam::<AWS_ACCOUNT_ID>:role/argocd-${var.cluster_name}"
       policy_associations = {
         argocdAdminAccess = {
           policy_arn = "arn:aws:eks::aws:cluster-access-policy/AmazonEKSClusterAdminPolicy"

--- a/aws-github/terraform/aws/modules/workload-cluster/main.tf
+++ b/aws-github/terraform/aws/modules/workload-cluster/main.tf
@@ -25,7 +25,7 @@ module "eks" {
   access_entries = {
     "argocd_<AWS_ACCOUNT_ID>" = {
       cluster_name  = "${var.cluster_name}"
-      principal_arn = "arn:aws:iam::<AWS_ACCOUNT_ID>:role/argocd-${var.cluster_name}"
+      principal_arn = "arn:aws:iam::<AWS_ACCOUNT_ID>:role/argocd-<CLUSTER_NAME>"
       policy_associations = {
         argocdAdminAccess = {
           policy_arn = "arn:aws:eks::aws:cluster-access-policy/AmazonEKSClusterAdminPolicy"

--- a/aws-gitlab/templates/mgmt/components/argocd/argocd-cm.yaml
+++ b/aws-gitlab/templates/mgmt/components/argocd/argocd-cm.yaml
@@ -11,34 +11,3 @@ data:
     clientSecret: $argocd-oidc-secret:clientSecret
     requestedScopes: ["openid", "groups", "user", "profile", "email"]
     requestedIDTokenClaims: {"groups": {"essential": true}}
-
-  resource.customizations: |
-    tf.upbound.io/Workspace:
-      health.lua: |
-        local hs = {}
-        if obj.status ~= nil then
-          if obj.status.conditions ~= nil then
-            local installed = false
-            local healthy = false
-            for i, condition in ipairs(obj.status.conditions) do
-              if condition.type == "Ready" then
-                installed = condition.status == "True"
-                installed_message = condition.reason
-              elseif condition.type == "Synced" then
-                healthy = condition.status == "True"
-                healthy_message = condition.reason
-              end
-            end
-            if installed and healthy then
-              hs.status = "Healthy"
-            else
-              hs.status = "Degraded"
-            end
-            hs.message = installed_message .. " " .. healthy_message
-            return hs
-          end
-        end
-        
-        hs.status = "Progressing"
-        hs.message = "Waiting for wworkspace to finish running"
-        return hs      

--- a/aws-gitlab/templates/mgmt/components/argocd/kustomization.yaml
+++ b/aws-gitlab/templates/mgmt/components/argocd/kustomization.yaml
@@ -5,7 +5,7 @@ namespace: argocd
 # To upgrade ArgoCD, increment the version here
 # https://github.com/argoproj/argo-cd/tags
 resources:
-  - github.com:konstructio/manifests.git/argocd/cloud?ref=v1.1.0
+  - github.com:konstructio/manifests.git/argocd/cloud?ref=v1.1.1
   - argocd-ui-ingress.yaml
   - externalsecrets.yaml
   - argocd-oidc-restart-job.yaml

--- a/aws-gitlab/terraform/aws/modules/workload-cluster/main.tf
+++ b/aws-gitlab/terraform/aws/modules/workload-cluster/main.tf
@@ -27,7 +27,7 @@ module "eks" {
   access_entries = {
     "argocd_<AWS_ACCOUNT_ID>" = {
       cluster_name  = "${var.cluster_name}"
-      principal_arn = "arn:aws:iam::<AWS_ACCOUNT_ID>:role/argocd-<AWS_ACCOUNT_ID>"
+      principal_arn = "arn:aws:iam::<AWS_ACCOUNT_ID>:role/argocd-${var.cluster_name}"
       policy_associations = {
         argocdAdminAccess = {
           policy_arn = "arn:aws:eks::aws:cluster-access-policy/AmazonEKSClusterAdminPolicy"
@@ -70,8 +70,6 @@ module "eks" {
   vpc_id                   = module.vpc.vpc_id
   subnet_ids               = module.vpc.private_subnets
   control_plane_subnet_ids = module.vpc.intra_subnets
-
-  manage_aws_auth_configmap = false
 
   # aws_auth_roles = [
   #   # managed node group is automatically added to the configmap

--- a/aws-gitlab/terraform/aws/modules/workload-cluster/main.tf
+++ b/aws-gitlab/terraform/aws/modules/workload-cluster/main.tf
@@ -27,7 +27,7 @@ module "eks" {
   access_entries = {
     "argocd_<AWS_ACCOUNT_ID>" = {
       cluster_name  = "${var.cluster_name}"
-      principal_arn = "arn:aws:iam::<AWS_ACCOUNT_ID>:role/argocd-${var.cluster_name}"
+      principal_arn = "arn:aws:iam::<AWS_ACCOUNT_ID>:role/argocd-<CLUSTER_NAME>"
       policy_associations = {
         argocdAdminAccess = {
           policy_arn = "arn:aws:eks::aws:cluster-access-policy/AmazonEKSClusterAdminPolicy"

--- a/civo-github/templates/mgmt/components/argocd/kustomization.yaml
+++ b/civo-github/templates/mgmt/components/argocd/kustomization.yaml
@@ -5,7 +5,7 @@ namespace: argocd
 # To upgrade ArgoCD, increment the version here
 # https://github.com/argoproj/argo-cd/tags
 resources:
-  - github.com:konstructio/manifests.git/argocd/cloud?ref=v1.1.0
+  - github.com:konstructio/manifests.git/argocd/cloud?ref=v1.1.1
   - argocd-ui-ingress.yaml
   - externalsecrets.yaml
   - argocd-oidc-restart-job.yaml

--- a/civo-gitlab/templates/mgmt/components/argocd/kustomization.yaml
+++ b/civo-gitlab/templates/mgmt/components/argocd/kustomization.yaml
@@ -5,7 +5,7 @@ namespace: argocd
 # To upgrade ArgoCD, increment the version here
 # https://github.com/argoproj/argo-cd/tags
 resources:
-  - github.com:konstructio/manifests.git/argocd/cloud?ref=v1.1.0
+  - github.com:konstructio/manifests.git/argocd/cloud?ref=v1.1.1
   - argocd-ui-ingress.yaml
   - externalsecrets.yaml
   - argocd-oidc-restart-job.yaml

--- a/digitalocean-github/templates/mgmt/components/argocd/kustomization.yaml
+++ b/digitalocean-github/templates/mgmt/components/argocd/kustomization.yaml
@@ -5,7 +5,7 @@ namespace: argocd
 # To upgrade ArgoCD, increment the version here
 # https://github.com/argoproj/argo-cd/tags
 resources:
-  - github.com:konstructio/manifests.git/argocd/cloud?ref=v1.1.0
+  - github.com:konstructio/manifests.git/argocd/cloud?ref=v1.1.1
   - argocd-ui-ingress.yaml
   - externalsecrets.yaml
   - argocd-oidc-restart-job.yaml

--- a/digitalocean-gitlab/templates/mgmt/components/argocd/kustomization.yaml
+++ b/digitalocean-gitlab/templates/mgmt/components/argocd/kustomization.yaml
@@ -5,7 +5,7 @@ namespace: argocd
 # To upgrade ArgoCD, increment the version here
 # https://github.com/argoproj/argo-cd/tags
 resources:
-  - github.com:konstructio/manifests.git/argocd/cloud?ref=v1.1.0
+  - github.com:konstructio/manifests.git/argocd/cloud?ref=v1.1.1
   - argocd-ui-ingress.yaml
   - externalsecrets.yaml
   - argocd-oidc-restart-job.yaml

--- a/google-github/templates/mgmt/components/argocd/kustomization.yaml
+++ b/google-github/templates/mgmt/components/argocd/kustomization.yaml
@@ -5,7 +5,7 @@ namespace: argocd
 # To upgrade ArgoCD, increment the version here
 # https://github.com/argoproj/argo-cd/tags
 resources:
-  - github.com:konstructio/manifests.git/argocd/cloud?ref=v1.1.0
+  - github.com:konstructio/manifests.git/argocd/cloud?ref=v1.1.1
   - argocd-ui-ingress.yaml
   - externalsecrets.yaml
   - argocd-oidc-restart-job.yaml

--- a/google-gitlab/templates/mgmt/components/argocd/kustomization.yaml
+++ b/google-gitlab/templates/mgmt/components/argocd/kustomization.yaml
@@ -5,7 +5,7 @@ namespace: argocd
 # To upgrade ArgoCD, increment the version here
 # https://github.com/argoproj/argo-cd/tags
 resources:
-  - github.com:konstructio/manifests.git/argocd/cloud?ref=v1.1.0
+  - github.com:konstructio/manifests.git/argocd/cloud?ref=v1.1.1
   - argocd-ui-ingress.yaml
   - externalsecrets.yaml
   - argocd-oidc-restart-job.yaml

--- a/k3s-github/templates/mgmt/components/argocd/kustomization.yaml
+++ b/k3s-github/templates/mgmt/components/argocd/kustomization.yaml
@@ -5,7 +5,7 @@ namespace: argocd
 # To upgrade ArgoCD, increment the version here
 # https://github.com/argoproj/argo-cd/tags
 resources:
-  - github.com:konstructio/manifests.git/argocd/cloud?ref=v1.1.0
+  - github.com:konstructio/manifests.git/argocd/cloud?ref=v1.1.1
   - argocd-ui-ingress.yaml
   - externalsecrets.yaml
   - argocd-oidc-restart-job.yaml

--- a/k3s-gitlab/templates/mgmt/components/argocd/kustomization.yaml
+++ b/k3s-gitlab/templates/mgmt/components/argocd/kustomization.yaml
@@ -5,7 +5,7 @@ namespace: argocd
 # To upgrade ArgoCD, increment the version here
 # https://github.com/argoproj/argo-cd/tags
 resources:
-  - github.com:konstructio/manifests.git/argocd/cloud?ref=v1.1.0
+  - github.com:konstructio/manifests.git/argocd/cloud?ref=v1.1.1
   - argocd-ui-ingress.yaml
   - externalsecrets.yaml
   - argocd-oidc-restart-job.yaml

--- a/vultr-github/templates/mgmt/components/argocd/kustomization.yaml
+++ b/vultr-github/templates/mgmt/components/argocd/kustomization.yaml
@@ -5,7 +5,7 @@ namespace: argocd
 # To upgrade ArgoCD, increment the version here
 # https://github.com/argoproj/argo-cd/tags
 resources:
-  - github.com:konstructio/manifests.git/argocd/cloud?ref=v1.1.0
+  - github.com:konstructio/manifests.git/argocd/cloud?ref=v1.1.1
   - argocd-ui-ingress.yaml
   - externalsecrets.yaml
   - argocd-oidc-restart-job.yaml

--- a/vultr-gitlab/templates/mgmt/components/argocd/kustomization.yaml
+++ b/vultr-gitlab/templates/mgmt/components/argocd/kustomization.yaml
@@ -5,7 +5,7 @@ namespace: argocd
 # To upgrade ArgoCD, increment the version here
 # https://github.com/argoproj/argo-cd/tags
 resources:
-  - github.com:konstructio/manifests.git/argocd/cloud?ref=v1.1.0
+  - github.com:konstructio/manifests.git/argocd/cloud?ref=v1.1.1
   - argocd-ui-ingress.yaml
   - externalsecrets.yaml
   - argocd-oidc-restart-job.yaml


### PR DESCRIPTION
This PR
- Fix: change suffix for principalARN from `cluster name` to management's cluster name
- Update argo-cd manifest to v1.1.1 which includes resource health check for Crossplane Workspace resource. 