### PR TITLE
feat(aws): gracefully restart argocd server and application controller

### DIFF
--- a/aws-github/templates/mgmt/components/argocd/argocd-oidc-restart-job.yaml
+++ b/aws-github/templates/mgmt/components/argocd/argocd-oidc-restart-job.yaml
@@ -57,7 +57,8 @@ spec:
              (kubectl rollout restart deploy --selector app.kubernetes.io/name=argocd-server -n argocd 
              && echo "Restarting argocd-server pod's" ) || echo "Unable to restart ArgoCD application controller";
 
-             (kubectl rollout restart sts --selector app.kubernetes.io/name=argocd-application-controller -n argocd && echo "Restarting argocd-application-controller pod's" ) || echo "Unable to restart ArgoCD application controller"
+             (kubectl rollout restart sts --selector app.kubernetes.io/name=argocd-application-controller -n argocd 
+             && echo "Restarting argocd-application-controller pod's" ) || echo "Unable to restart ArgoCD application controller"
       restartPolicy: OnFailure
       serviceAccountName: argocd-oidc-restart-job
 

--- a/aws-github/templates/mgmt/components/argocd/argocd-oidc-restart-job.yaml
+++ b/aws-github/templates/mgmt/components/argocd/argocd-oidc-restart-job.yaml
@@ -44,6 +44,8 @@ kind: Job
 metadata:
   name: argocd-oidc-restart-job
   namespace: argocd
+  annotations:
+    argocd.argoproj.io/hook: PostSync
 spec:
   template:
     spec:

--- a/aws-github/templates/mgmt/components/argocd/argocd-oidc-restart-job.yaml
+++ b/aws-github/templates/mgmt/components/argocd/argocd-oidc-restart-job.yaml
@@ -15,6 +15,7 @@ rules:
       - apps
     resources:
       - deployments
+      - statefulsets
     verbs:
       - get
       - list
@@ -48,11 +49,15 @@ spec:
     spec:
       containers:
         - name: argocd-oidc-restart-job
-          image: public.ecr.aws/bitnami/kubectl:1.24
-          command:
-            - /bin/sh
-            - -c
-            - echo restarting argocd-server in 15 seconds && sleep 15 && echo restarting && kubectl -n argocd get deployment/argocd-server -oyaml | kubectl -n argocd replace --force -f -
+          image: public.ecr.aws/bitnami/kubectl:1.28
+          command: ["/bin/sh", "-c"]
+          args:
+            - echo "Give me time to think" && sleep 15;
+
+             (kubectl rollout restart deploy --selector app.kubernetes.io/name=argocd-server -n argocd 
+             && echo "Restarting argocd-server pod's" ) || echo "Unable to restart ArgoCD application controller";
+
+             (kubectl rollout restart sts --selector app.kubernetes.io/name=argocd-application-controller -n argocd && echo "Restarting argocd-application-controller pod's" ) || echo "Unable to restart ArgoCD application controller"
       restartPolicy: OnFailure
       serviceAccountName: argocd-oidc-restart-job
 

--- a/aws-gitlab/templates/mgmt/components/argocd/argocd-oidc-restart-job.yaml
+++ b/aws-gitlab/templates/mgmt/components/argocd/argocd-oidc-restart-job.yaml
@@ -44,6 +44,8 @@ kind: Job
 metadata:
   name: argocd-oidc-restart-job
   namespace: argocd
+  annotations:
+    argocd.argoproj.io/hook: PostSync
 spec:
   template:
     spec:

--- a/aws-gitlab/templates/mgmt/components/argocd/argocd-oidc-restart-job.yaml
+++ b/aws-gitlab/templates/mgmt/components/argocd/argocd-oidc-restart-job.yaml
@@ -15,6 +15,7 @@ rules:
       - apps
     resources:
       - deployments
+      - statefulsets
     verbs:
       - get
       - list
@@ -48,10 +49,15 @@ spec:
     spec:
       containers:
         - name: argocd-oidc-restart-job
-          image: public.ecr.aws/bitnami/kubectl:1.24
-          command:
-            - /bin/sh
-            - -c
-            - echo restarting argocd-server in 15 seconds && sleep 15 && echo restarting && kubectl -n argocd get deployment/argocd-server -oyaml | kubectl -n argocd replace --force -f -
+          image: public.ecr.aws/bitnami/kubectl:1.28
+          command: ["/bin/sh", "-c"]
+          args:
+            - echo "Give me time to think" && sleep 15;
+
+             (kubectl rollout restart deploy --selector app.kubernetes.io/name=argocd-server -n argocd 
+             && echo "Restarting argocd-server pod's" ) || echo "Unable to restart ArgoCD application controller";
+
+             (kubectl rollout restart sts --selector app.kubernetes.io/name=argocd-application-controller -n argocd 
+             && echo "Restarting argocd-application-controller pod's" ) || echo "Unable to restart ArgoCD application controller"
       restartPolicy: OnFailure
       serviceAccountName: argocd-oidc-restart-job


### PR DESCRIPTION
## Description

For various reasons Argo CD is a two part installation; where it is intially installed from [here](https://github.com/konstructio/gitops-template/blob/main/aws-github/templates/mgmt/components/argocd/argocd-oidc-restart-job.yaml) and then once it is up it takes controller of managing and patching itself. Seconds steps involves performing cloud specific operation such as annotation the service account with IAM role arn. Since there is no straight forward mechanics to trigger a rollout when using Kustomize, unlike Helm where you can add an annotation with the SHA of the service account or resource you are dependent on. This PR updates an existing job to gracefully restart ArgoCD server and application controller. 

## Related Issue(s)
(AWS) ArgoCD fails to communicate with downstream clusters.

## How to test
Create a test cluster using this branch. Once the Kubernetes platform is up create a downstream cluster(doesn't matter if it is in the same account or downstream account). Then head over to settings > clusters and check if Argo is able to connect to your cluster successfully.
