### PR TITLE
feat: add json file in terraform for Civo Multi account

### DIFF
--- a/civo-github/templates/gpu-cluster/provider-config/providerconfig.yaml
+++ b/civo-github/templates/gpu-cluster/provider-config/providerconfig.yaml
@@ -22,7 +22,7 @@ spec:
         required_providers {
           civo = {
             source  = "civo/civo"
-            version = "~> 1.1.0"
+            version = "= 1.1.0"
           }
           helm = {
             source = "hashicorp/helm"
@@ -39,7 +39,7 @@ spec:
     source: Secret
     secretRef:
       namespace: crossplane-system
-      name: civo-creds
+      name: <WORKLOAD_CIVO_ACCOUNT_NAME>-civo-creds
       key: config.json
   - filename: .git-credentials
     source: Secret

--- a/civo-github/templates/gpu-cluster/provider-config/providerconfig.yaml
+++ b/civo-github/templates/gpu-cluster/provider-config/providerconfig.yaml
@@ -31,15 +31,16 @@ spec:
         }
       }
       provider "civo" {
+        credentials_file = "civo.json"
         region = "<WORKLOAD_CLUSTER_REGION>"
       }
   credentials:
-  - filename: gen-nothing
-    source: None
+  - filename: civo.json
+    source: Secret
     secretRef:
       namespace: crossplane-system
       name: civo-creds
-      key: token
+      key: config.json
   - filename: .git-credentials
     source: Secret
     secretRef:

--- a/civo-github/templates/mgmt/cloud-accounts.yaml
+++ b/civo-github/templates/mgmt/cloud-accounts.yaml
@@ -1,0 +1,22 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: cloud-accounts
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: '60'
+spec:
+  project: default
+  source:
+    repoURL: <GITOPS_REPO_URL>
+    path: registry/clusters/<CLUSTER_NAME>/components/cloud-accounts
+    targetRevision: HEAD
+  destination:
+    name: in-cluster
+    namespace: crossplane-system
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/civo-github/templates/mgmt/components/cloud-accounts/default-civo-account.yaml
+++ b/civo-github/templates/mgmt/components/cloud-accounts/default-civo-account.yaml
@@ -1,0 +1,31 @@
+apiVersion: "external-secrets.io/v1beta1"
+kind: ExternalSecret
+metadata:
+  name: default-civo-cloud-account
+  labels:
+    kubefirst.konstruct.io/cloud: civo
+    kubefirst.konstruct.io/type: cloud-account
+spec:
+  target:
+    name: default-civo-account
+    template:
+      engineVersion: v2
+      data:
+        config.json: |
+          {
+              "apikeys": {
+                  "tf_key": {{ .civo_token | squote }}
+              },
+              "meta": {
+                  "current_apikey": "tf_key"
+              }
+          }
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: vault-kv-secret
+  refreshInterval: 10s
+  data:
+    - remoteRef:
+        key: cloud-accounts/civo/default
+        property: civo_token
+      secretKey: civo_token

--- a/civo-github/templates/workload-cluster/provider-config/providerconfig.yaml
+++ b/civo-github/templates/workload-cluster/provider-config/providerconfig.yaml
@@ -22,7 +22,7 @@ spec:
         required_providers {
           civo = {
             source  = "civo/civo"
-            version = "~> 1.1.0"
+            version = "= 1.1.0"
           }
         }
       }
@@ -35,7 +35,7 @@ spec:
     source: Secret
     secretRef:
       namespace: crossplane-system
-      name: civo-creds
+      name: <WORKLOAD_CIVO_ACCOUNT_NAME>-civo-creds
       key: config.json
   - filename: .git-credentials
     source: Secret

--- a/civo-github/templates/workload-cluster/provider-config/providerconfig.yaml
+++ b/civo-github/templates/workload-cluster/provider-config/providerconfig.yaml
@@ -27,15 +27,16 @@ spec:
         }
       }
       provider "civo" {
+        credentials_file = "civo.json"
         region = "<WORKLOAD_CLUSTER_REGION>"
       }
   credentials:
-  - filename: gen-nothing
-    source: None
+  - filename: civo.json
+    source: Secret
     secretRef:
       namespace: crossplane-system
       name: civo-creds
-      key: token
+      key: config.json
   - filename: .git-credentials
     source: Secret
     secretRef:

--- a/civo-github/terraform/vault/secrets.tf
+++ b/civo-github/terraform/vault/secrets.tf
@@ -35,7 +35,6 @@ resource "vault_generic_secret" "crossplane" {
     {
       AWS_ACCESS_KEY_ID     = var.aws_access_key_id,
       AWS_SECRET_ACCESS_KEY = var.aws_secret_access_key,
-      CIVO_TOKEN            = var.civo_token
       VAULT_ADDR            = "http://vault.vault.svc.cluster.local:8200"
       VAULT_TOKEN           = var.vault_token
       password              = var.github_token

--- a/civo-gitlab/templates/gpu-cluster/provider-config/providerconfig.yaml
+++ b/civo-gitlab/templates/gpu-cluster/provider-config/providerconfig.yaml
@@ -22,7 +22,7 @@ spec:
         required_providers {
           civo = {
             source  = "civo/civo"
-            version = "~> 1.1.0"
+            version = "= 1.1.0"
           }
           helm = {
             source = "hashicorp/helm"
@@ -39,7 +39,7 @@ spec:
     source: Secret
     secretRef:
       namespace: crossplane-system
-      name: civo-creds
+      name: <WORKLOAD_CIVO_ACCOUNT_NAME>-civo-creds
       key: config.json
   - filename: .git-credentials
     source: Secret

--- a/civo-gitlab/templates/gpu-cluster/provider-config/providerconfig.yaml
+++ b/civo-gitlab/templates/gpu-cluster/provider-config/providerconfig.yaml
@@ -31,15 +31,16 @@ spec:
         }
       }
       provider "civo" {
+        credentials_file = "civo.json"
         region = "<WORKLOAD_CLUSTER_REGION>"
       }
   credentials:
-  - filename: gen-nothing
-    source: None
+  - filename: civo.json
+    source: Secret
     secretRef:
       namespace: crossplane-system
       name: civo-creds
-      key: token
+      key: config.json
   - filename: .git-credentials
     source: Secret
     secretRef:

--- a/civo-gitlab/templates/workload-cluster/provider-config/providerconfig.yaml
+++ b/civo-gitlab/templates/workload-cluster/provider-config/providerconfig.yaml
@@ -33,15 +33,16 @@ spec:
         }
       }
       provider "civo" {
+        credentials_file = "civo.json"
         region = "<WORKLOAD_CLUSTER_REGION>"
       }
   credentials:
-  - filename: gen-nothing
-    source: None
+  - filename: civo.json
+    source: Secret
     secretRef:
       namespace: crossplane-system
       name: civo-creds
-      key: token
+      key: config.json
   - filename: .git-credentials
     source: Secret
     secretRef:

--- a/civo-gitlab/templates/workload-cluster/provider-config/providerconfig.yaml
+++ b/civo-gitlab/templates/workload-cluster/provider-config/providerconfig.yaml
@@ -20,7 +20,7 @@ spec:
         required_providers {
           civo = {
             source = "civo/civo"
-            version = "~> 1.1.0"
+            version = "= 1.1.0"
           }
           kubernetes = {
             source = "hashicorp/kubernetes"
@@ -41,7 +41,7 @@ spec:
     source: Secret
     secretRef:
       namespace: crossplane-system
-      name: civo-creds
+      name: <WORKLOAD_CIVO_ACCOUNT_NAME>-civo-creds
       key: config.json
   - filename: .git-credentials
     source: Secret

--- a/civo-gitlab/terraform/vault/secrets.tf
+++ b/civo-gitlab/terraform/vault/secrets.tf
@@ -137,7 +137,6 @@ resource "vault_generic_secret" "crossplane" {
     {
       AWS_ACCESS_KEY_ID     = var.aws_access_key_id,
       AWS_SECRET_ACCESS_KEY = var.aws_secret_access_key,
-      CIVO_TOKEN            = var.civo_token
       VAULT_ADDR            = "http://vault.vault.svc.cluster.local:8200"
       VAULT_TOKEN           = var.vault_token
       password              = var.gitlab_token


### PR DESCRIPTION
## Description
1.Remove Civo Token from Vault Secrets:

The Civo API token has been removed from the secrets stored in Vault. The Crossplane Terraform provider will no longer utilize this token

2.Reference JSON Secret During Provisioning:

A JSON secret, created at the time of provisioning, will be referenced in the Crossplane system from Vault. This secret will be utilized during the provisioning process and subsequently deleted from the Crossplane namespace once the cluster has been provisioned.

## Testing 
pass the flag of "--gitops-template-branch civo-multi-account" when proivisoning a cluster and test the multiaccount provisioning by inserting appropriate keys for downstream accounts