### PR TITLE
fix: download the stable 1.1.0 Civo tf provider

### DIFF
--- a/civo-github/templates/gpu-cluster/provider-config/providerconfig.yaml
+++ b/civo-github/templates/gpu-cluster/provider-config/providerconfig.yaml
@@ -22,7 +22,7 @@ spec:
         required_providers {
           civo = {
             source  = "civo/civo"
-            version = "~> 1.1.0"
+            version = "= 1.1.0"
           }
           helm = {
             source = "hashicorp/helm"

--- a/civo-github/templates/workload-cluster/provider-config/providerconfig.yaml
+++ b/civo-github/templates/workload-cluster/provider-config/providerconfig.yaml
@@ -22,7 +22,7 @@ spec:
         required_providers {
           civo = {
             source  = "civo/civo"
-            version = "~> 1.1.0"
+            version = "= 1.1.0"
           }
         }
       }

--- a/civo-github/terraform/civo/main.tf
+++ b/civo-github/terraform/civo/main.tf
@@ -14,7 +14,7 @@ terraform {
   required_providers {
     civo = {
       source = "civo/civo"
-      version = "~> 1.1.0"
+      version = "= 1.1.0"
     }
   }
 }

--- a/civo-gitlab/templates/gpu-cluster/provider-config/providerconfig.yaml
+++ b/civo-gitlab/templates/gpu-cluster/provider-config/providerconfig.yaml
@@ -22,7 +22,7 @@ spec:
         required_providers {
           civo = {
             source  = "civo/civo"
-            version = "~> 1.1.0"
+            version = "= 1.1.0"
           }
           helm = {
             source = "hashicorp/helm"

--- a/civo-gitlab/templates/workload-cluster/provider-config/providerconfig.yaml
+++ b/civo-gitlab/templates/workload-cluster/provider-config/providerconfig.yaml
@@ -20,7 +20,7 @@ spec:
         required_providers {
           civo = {
             source = "civo/civo"
-            version = "~> 1.1.0"
+            version = "= 1.1.0"
           }
           kubernetes = {
             source = "hashicorp/kubernetes"

--- a/civo-gitlab/terraform/civo/main.tf
+++ b/civo-gitlab/terraform/civo/main.tf
@@ -14,7 +14,7 @@ terraform {
   required_providers {
     civo = {
       source = "civo/civo"
-      version = "~> 1.1.0"
+      version = "= 1.1.0"
     }
   }
 }


### PR DESCRIPTION
## Description
download the 1.1.0 version rather than the latest version ,as the latest version has breaking changes for naming convention
