### PR TITLE
fix(azure-github): update the ingress-nginx config

### DIFF
--- a/azure-github/templates/workload-vcluster/30-ingress-nginx.yaml
+++ b/azure-github/templates/workload-vcluster/30-ingress-nginx.yaml
@@ -22,8 +22,8 @@ spec:
             enabled: true
           service:
             annotations:
-              service.beta.kubernetes.io/aws-load-balancer-ssl-ports: "https"
-              service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: "60"
+              service.beta.kubernetes.io/azure-load-balancer-health-probe-request-path: /healthz
+            externalTrafficPolicy: Local
           extraArgs:
             enable-ssl-passthrough: true
     chart: ingress-nginx


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
For vclusters, this correctly routes traffic (previously wasn't working at all as had forgotten to check it).

## Related Issue(s)
<!-- List the issue(s) this PR solves. An issue should be raised before creating a PR -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

1. Deploy an Azure cluster and check the load balancer's healthcheck.
2. Create a vcluster and deploy flappy-kray

Or, use my existing cluster - https://flappy-kray.azure-kubefirst4.simonemms.com/

