### PR TITLE
fix(azure): update argo workflows to store artifacts correctly

### DIFF
--- a/azure-github/templates/mgmt/components/argo-workflows/application.yaml
+++ b/azure-github/templates/mgmt/components/argo-workflows/application.yaml
@@ -21,7 +21,14 @@ spec:
             limits:
               cpu: 1
               memory: 1024Mi
+        controller:
+          deploymentAnnotations:
+            configmap.reloader.stakater.com/reload: argo-workflow-controller-configmap
+            secret.reloader.stakater.com/reload: azure-storage-credentials
         server:
+          deploymentAnnotations:
+            configmap.reloader.stakater.com/reload: argo-workflow-controller-configmap
+            secret.reloader.stakater.com/reload: azure-storage-credentials
           secure: false
           extraArgs:
           - --auth-mode=client
@@ -66,8 +73,13 @@ spec:
         artifactRepository:
           archiveLogs: false
           azure:
-            container: <KUBEFIRST_STATE_STORE_BUCKET>
-            useSDKCreds: true
+            endpoint: https://<KUBEFIRST_STATE_STORE_BUCKET>.blob.core.windows.net
+            blobNameFormat: "argo-workflows/artifacts/{{workflow.creationTimestamp.Y}}/{{workflow.creationTimestamp.m}}/{{workflow.creationTimestamp.d}}/{{workflow.uid}}/{{workflow.name}}/{{pod.name}}"
+            container: <KUBEFIRST_STATE_STORE_CONTAINER_NAME>
+            useSDKCreds: false
+            accountKeySecret:
+              name: azure-storage-credentials
+              key: account-access-key
     chart: argo-workflows
   destination:
     name: in-cluster

--- a/azure-github/templates/mgmt/components/argo-workflows/externalsecret.yaml
+++ b/azure-github/templates/mgmt/components/argo-workflows/externalsecret.yaml
@@ -57,3 +57,22 @@ spec:
         key: registry-auth
         property: auth
       secretKey: config.json
+---
+apiVersion: 'external-secrets.io/v1beta1'
+kind: ExternalSecret
+metadata:
+  name: azure-storage-credentials
+  annotations:
+    argocd.argoproj.io/sync-wave: '0'
+spec:
+  target:
+    name: azure-storage-credentials
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: vault-kv-secret
+  refreshInterval: 10s
+  data:
+    - remoteRef:
+        key: chartmuseum
+        property: AZURE_STORAGE_ACCESS_KEY
+      secretKey: account-access-key

--- a/azure-gitlab/templates/mgmt/components/argo-workflows/application.yaml
+++ b/azure-gitlab/templates/mgmt/components/argo-workflows/application.yaml
@@ -21,7 +21,14 @@ spec:
             limits:
               cpu: 1
               memory: 1024Mi
+        controller:
+          deploymentAnnotations:
+            configmap.reloader.stakater.com/reload: argo-workflow-controller-configmap
+            secret.reloader.stakater.com/reload: azure-storage-credentials
         server:
+          deploymentAnnotations:
+            configmap.reloader.stakater.com/reload: argo-workflow-controller-configmap
+            secret.reloader.stakater.com/reload: azure-storage-credentials
           secure: false
           extraArgs:
           - --auth-mode=client
@@ -66,8 +73,13 @@ spec:
         artifactRepository:
           archiveLogs: false
           azure:
-            container: <KUBEFIRST_STATE_STORE_BUCKET>
-            useSDKCreds: true
+            endpoint: https://<KUBEFIRST_STATE_STORE_BUCKET>.blob.core.windows.net
+            blobNameFormat: "argo-workflows/artifacts/{{workflow.creationTimestamp.Y}}/{{workflow.creationTimestamp.m}}/{{workflow.creationTimestamp.d}}/{{workflow.uid}}/{{workflow.name}}/{{pod.name}}"
+            container: <KUBEFIRST_STATE_STORE_CONTAINER_NAME>
+            useSDKCreds: false
+            accountKeySecret:
+              name: azure-storage-credentials
+              key: account-access-key
     chart: argo-workflows
   destination:
     name: in-cluster

--- a/azure-gitlab/templates/mgmt/components/argo-workflows/externalsecret.yaml
+++ b/azure-gitlab/templates/mgmt/components/argo-workflows/externalsecret.yaml
@@ -56,3 +56,22 @@ spec:
       key: deploy-tokens/container-registry-auth
       property: auth
     secretKey: config.json
+---
+apiVersion: 'external-secrets.io/v1beta1'
+kind: ExternalSecret
+metadata:
+  name: azure-storage-credentials
+  annotations:
+    argocd.argoproj.io/sync-wave: '0'
+spec:
+  target:
+    name: azure-storage-credentials
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: vault-kv-secret
+  refreshInterval: 10s
+  data:
+    - remoteRef:
+        key: chartmuseum
+        property: AZURE_STORAGE_ACCESS_KEY
+      secretKey: account-access-key


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Updates the Argo workflow configuration is done so that the artifacts are stored correctly. The storage container uses credentials from the ChartMuseum Vault secret.

- [Working GitHub Action](https://github.com/mrsimonemmsorg2/metaphor/actions/runs/12031531209)
- [Working GitLab Action](https://gitlab.com/sje-kubefirst/metaphor/-/pipelines/1561052814)

This now publishes the Metaphor app to the cluster:
 - [GitHub example](https://metaphor-development.azure2.kubefirst.simonemms.com/)
 - [GitLab example](https://metaphor-development.azure3.kubefirst.simonemms.com/)

I've added [Reload](https://docs.stakater.com/reloader/) annotations to the server and controller for the configmap and secrets used to reload the pods if the configmap and secret changes - if there's an already workflow, this doesn't affect it as they're run as separate jobs (but it would likely fail anyway as the configuration has changed).

## Related Issue(s)
<!-- List the issue(s) this PR solves. An issue should be raised before creating a PR -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
Deploy an Azure app and watch Metaphor run. I have demos if you want to pair
