### PR TITLE
feat[chart][kubefirst]: use a fullnameoveride

### DIFF
--- a/akamai-github/templates/mgmt/components/kubefirst/console.yaml
+++ b/akamai-github/templates/mgmt/components/kubefirst/console.yaml
@@ -26,9 +26,11 @@ spec:
           kubefirstVersion: "<KUBEFIRST_VERSION>"
           useTelemetry: "<USE_TELEMETRY>"
         kubefirst-pro-api:
+          fullnameOverride: "kubefirst-pro-api"
           extraEnv:
             CLUSTER_NAME: "<CLUSTER_NAME>"
         kubefirst-pro-ui:
+          fullnameOverride: "kubefirst-pro-ui"
           domain: "<DOMAIN_NAME>"
           extraEnvSecrets:
             CLIENT_ID:

--- a/aws-github/templates/mgmt/components/kubefirst/console.yaml
+++ b/aws-github/templates/mgmt/components/kubefirst/console.yaml
@@ -26,6 +26,7 @@ spec:
           kubefirstVersion: "<KUBEFIRST_VERSION>"
           useTelemetry: "<USE_TELEMETRY>"
         kubefirst-pro-api:
+          fullnameOverride: "kubefirst-pro-api"
           extraEnv:
             CLUSTER_NAME: "<CLUSTER_NAME>"
           serviceAccount:
@@ -33,6 +34,7 @@ spec:
             annotations: 
               eks.amazonaws.com/role-arn: arn:aws:iam::<AWS_ACCOUNT_ID>:role/kubefirst-pro-api-<CLUSTER_NAME>
         kubefirst-pro-ui:
+          fullnameOverride: "kubefirst-pro-ui"
           domain: "<DOMAIN_NAME>"
           extraEnvSecrets:
             CLIENT_ID:

--- a/aws-gitlab/templates/mgmt/components/kubefirst/console.yaml
+++ b/aws-gitlab/templates/mgmt/components/kubefirst/console.yaml
@@ -26,6 +26,7 @@ spec:
           kubefirstVersion: "<KUBEFIRST_VERSION>"
           useTelemetry: "<USE_TELEMETRY>"
         kubefirst-pro-api:
+          fullnameOverride: "kubefirst-pro-api"
           extraEnv:
             CLUSTER_NAME: "<CLUSTER_NAME>"
           serviceAccount:
@@ -33,6 +34,7 @@ spec:
             annotations: 
               eks.amazonaws.com/role-arn: arn:aws:iam::<AWS_ACCOUNT_ID>:role/kubefirst-pro-api-<CLUSTER_NAME>
         kubefirst-pro-ui:
+          fullnameOverride: "kubefirst-pro-ui"
           domain: "<DOMAIN_NAME>"
           extraEnvSecrets:
             CLIENT_ID:

--- a/azure-github/templates/mgmt/components/kubefirst/console.yaml
+++ b/azure-github/templates/mgmt/components/kubefirst/console.yaml
@@ -26,9 +26,11 @@ spec:
           kubefirstVersion: "<KUBEFIRST_VERSION>"
           useTelemetry: "<USE_TELEMETRY>"
         kubefirst-pro-api:
+          fullnameOverride: "kubefirst-pro-api"
           extraEnv:
             CLUSTER_NAME: "<CLUSTER_NAME>"
         kubefirst-pro-ui:
+          fullnameOverride: "kubefirst-pro-ui"
           domain: "<DOMAIN_NAME>"
           extraEnvSecrets:
             CLIENT_ID:

--- a/azure-gitlab/templates/mgmt/components/kubefirst/console.yaml
+++ b/azure-gitlab/templates/mgmt/components/kubefirst/console.yaml
@@ -26,9 +26,11 @@ spec:
           kubefirstVersion: "<KUBEFIRST_VERSION>"
           useTelemetry: "<USE_TELEMETRY>"
         kubefirst-pro-api:
+          fullnameOverride: "kubefirst-pro-api"
           extraEnv:
             CLUSTER_NAME: "<CLUSTER_NAME>"
         kubefirst-pro-ui:
+          fullnameOverride: "kubefirst-pro-ui"
           domain: "<DOMAIN_NAME>"
           extraEnvSecrets:
             CLIENT_ID:

--- a/civo-github/templates/mgmt/components/kubefirst/console.yaml
+++ b/civo-github/templates/mgmt/components/kubefirst/console.yaml
@@ -26,9 +26,11 @@ spec:
           kubefirstVersion: "<KUBEFIRST_VERSION>"
           useTelemetry: "<USE_TELEMETRY>"
         kubefirst-pro-api:
+          fullnameOverride: "kubefirst-pro-api"
           extraEnv:
             CLUSTER_NAME: "<CLUSTER_NAME>"
         kubefirst-pro-ui:
+          fullnameOverride: "kubefirst-pro-ui"
           domain: "<DOMAIN_NAME>"
           extraEnvSecrets:
             CLIENT_ID:

--- a/civo-gitlab/templates/mgmt/components/kubefirst/console.yaml
+++ b/civo-gitlab/templates/mgmt/components/kubefirst/console.yaml
@@ -26,9 +26,11 @@ spec:
           kubefirstVersion: "<KUBEFIRST_VERSION>"
           useTelemetry: "<USE_TELEMETRY>"
         kubefirst-pro-api:
+          fullnameOverride: "kubefirst-pro-api"
           extraEnv:
             CLUSTER_NAME: "<CLUSTER_NAME>"
         kubefirst-pro-ui:
+          fullnameOverride: "kubefirst-pro-ui"
           domain: "<DOMAIN_NAME>"
           extraEnvSecrets:
             CLIENT_ID:

--- a/digitalocean-github/templates/mgmt/components/kubefirst/console.yaml
+++ b/digitalocean-github/templates/mgmt/components/kubefirst/console.yaml
@@ -26,9 +26,11 @@ spec:
           kubefirstVersion: "<KUBEFIRST_VERSION>"
           useTelemetry: "<USE_TELEMETRY>"
         kubefirst-pro-api:
+          fullnameOverride: "kubefirst-pro-api"
           extraEnv:
             CLUSTER_NAME: "<CLUSTER_NAME>"
         kubefirst-pro-ui:
+          fullnameOverride: "kubefirst-pro-ui"
           domain: "<DOMAIN_NAME>"
           extraEnvSecrets:
             CLIENT_ID:

--- a/digitalocean-gitlab/templates/mgmt/components/kubefirst/console.yaml
+++ b/digitalocean-gitlab/templates/mgmt/components/kubefirst/console.yaml
@@ -26,9 +26,11 @@ spec:
           kubefirstVersion: "<KUBEFIRST_VERSION>"
           useTelemetry: "<USE_TELEMETRY>"
         kubefirst-pro-api:
+          fullnameOverride: "kubefirst-pro-api"
           extraEnv:
             CLUSTER_NAME: "<CLUSTER_NAME>"
         kubefirst-pro-ui:
+          fullnameOverride: "kubefirst-pro-ui"
           domain: "<DOMAIN_NAME>"
           extraEnvSecrets:
             CLIENT_ID:

--- a/google-github/templates/mgmt/components/kubefirst/console.yaml
+++ b/google-github/templates/mgmt/components/kubefirst/console.yaml
@@ -26,9 +26,11 @@ spec:
           kubefirstVersion: "<KUBEFIRST_VERSION>"
           useTelemetry: "<USE_TELEMETRY>"
         kubefirst-pro-api:
+          fullnameOverride: "kubefirst-pro-api"
           extraEnv:
             CLUSTER_NAME: "<CLUSTER_NAME>"
         kubefirst-pro-ui:
+          fullnameOverride: "kubefirst-pro-ui"
           domain: "<DOMAIN_NAME>"
           extraEnvSecrets:
             CLIENT_ID:

--- a/google-gitlab/templates/mgmt/components/kubefirst/console.yaml
+++ b/google-gitlab/templates/mgmt/components/kubefirst/console.yaml
@@ -26,9 +26,11 @@ spec:
           kubefirstVersion: "<KUBEFIRST_VERSION>"
           useTelemetry: "<USE_TELEMETRY>"
         kubefirst-pro-api:
+          fullnameOverride: "kubefirst-pro-api"
           extraEnv:
             CLUSTER_NAME: "<CLUSTER_NAME>"
         kubefirst-pro-ui:
+          fullnameOverride: "kubefirst-pro-ui"
           domain: "<DOMAIN_NAME>"
           extraEnvSecrets:
             CLIENT_ID:

--- a/k3d-github/cluster-types/mgmt/components/kubefirst/console.yaml
+++ b/k3d-github/cluster-types/mgmt/components/kubefirst/console.yaml
@@ -26,9 +26,11 @@ spec:
           kubefirstVersion: "<KUBEFIRST_VERSION>"
           useTelemetry: "<USE_TELEMETRY>"
         kubefirst-pro-api:
+          fullnameOverride: "kubefirst-pro-api"
           extraEnv:
             CLUSTER_NAME: "<CLUSTER_NAME>"
         kubefirst-pro-ui:
+          fullnameOverride: "kubefirst-pro-ui"
           domain: "<DOMAIN_NAME>"
           extraEnv:
             DISABLE_AUTH: "true"

--- a/k3d-gitlab/cluster-types/mgmt/components/kubefirst/console.yaml
+++ b/k3d-gitlab/cluster-types/mgmt/components/kubefirst/console.yaml
@@ -26,9 +26,11 @@ spec:
           kubefirstVersion: "<KUBEFIRST_VERSION>"
           useTelemetry: "<USE_TELEMETRY>"
         kubefirst-pro-api:
+          fullnameOverride: "kubefirst-pro-api"
           extraEnv:
             CLUSTER_NAME: "<CLUSTER_NAME>"
         kubefirst-pro-ui:
+          fullnameOverride: "kubefirst-pro-ui"
           domain: "<DOMAIN_NAME>"
           extraEnv:
             DISABLE_AUTH: "true"

--- a/k3s-github/templates/mgmt/components/kubefirst/console.yaml
+++ b/k3s-github/templates/mgmt/components/kubefirst/console.yaml
@@ -26,9 +26,11 @@ spec:
           kubefirstVersion: "<KUBEFIRST_VERSION>"
           useTelemetry: "<USE_TELEMETRY>"
         kubefirst-pro-api:
+          fullnameOverride: "kubefirst-pro-api"
           extraEnv:
             CLUSTER_NAME: "<CLUSTER_NAME>"
         kubefirst-pro-ui:
+          fullnameOverride: "kubefirst-pro-ui"
           domain: "<DOMAIN_NAME>"
           extraEnvSecrets:
             CLIENT_ID:

--- a/k3s-gitlab/templates/mgmt/components/kubefirst/console.yaml
+++ b/k3s-gitlab/templates/mgmt/components/kubefirst/console.yaml
@@ -26,9 +26,11 @@ spec:
           kubefirstVersion: "<KUBEFIRST_VERSION>"
           useTelemetry: "<USE_TELEMETRY>"
         kubefirst-pro-api:
+          fullnameOverride: "kubefirst-pro-api"
           extraEnv:
             CLUSTER_NAME: "<CLUSTER_NAME>"
         kubefirst-pro-ui:
+          fullnameOverride: "kubefirst-pro-ui"
           domain: "<DOMAIN_NAME>"
           extraEnvSecrets:
             CLIENT_ID:

--- a/vultr-github/templates/mgmt/components/kubefirst/console.yaml
+++ b/vultr-github/templates/mgmt/components/kubefirst/console.yaml
@@ -26,9 +26,11 @@ spec:
           kubefirstVersion: "<KUBEFIRST_VERSION>"
           useTelemetry: "<USE_TELEMETRY>"
         kubefirst-pro-api:
+          fullnameOverride: "kubefirst-pro-api"
           extraEnv:
             CLUSTER_NAME: "<CLUSTER_NAME>"
         kubefirst-pro-ui:
+          fullnameOverride: "kubefirst-pro-ui"
           domain: "<DOMAIN_NAME>"
           extraEnvSecrets:
             CLIENT_ID:

--- a/vultr-gitlab/templates/mgmt/components/kubefirst/console.yaml
+++ b/vultr-gitlab/templates/mgmt/components/kubefirst/console.yaml
@@ -26,9 +26,11 @@ spec:
           kubefirstVersion: "<KUBEFIRST_VERSION>"
           useTelemetry: "<USE_TELEMETRY>"
         kubefirst-pro-api:
+          fullnameOverride: "kubefirst-pro-api"
           extraEnv:
             CLUSTER_NAME: "<CLUSTER_NAME>"
         kubefirst-pro-ui:
+          fullnameOverride: "kubefirst-pro-ui"
           domain: "<DOMAIN_NAME>"
           extraEnvSecrets:
             CLIENT_ID:


### PR DESCRIPTION
## Description
Add `fullNameOverride` field to Kubefirst sub-charts. 

## Related Issue(s)
Resources are apended with chart name (kubefirst) and makes it look duplicate. Deployment is named `kubefirst-kubefirst-api` instead of `kubefirst-api`

## How to test
Created a CKubefirst platform using this branch.
