### PR TITLE
fix: service account name

### DIFF
--- a/aws-github/terraform/aws/eks/main.tf
+++ b/aws-github/terraform/aws/eks/main.tf
@@ -623,7 +623,7 @@ module "kubefirst_api" {
   oidc_providers = {
     main = {
       provider_arn               = module.eks.oidc_provider_arn
-      namespace_service_accounts = ["kubefirst:kubefirst-kubefirst-pro-api"]
+      namespace_service_accounts = ["kubefirst:kubefirst-pro-api"]
     }
   }
 

--- a/aws-gitlab/terraform/aws/eks/main.tf
+++ b/aws-gitlab/terraform/aws/eks/main.tf
@@ -623,7 +623,7 @@ module "kubefirst_api" {
   oidc_providers = {
     main = {
       provider_arn               = module.eks.oidc_provider_arn
-      namespace_service_accounts = ["kubefirst:kubefirst-kubefirst-pro-api"]
+      namespace_service_accounts = ["kubefirst:kubefirst-pro-api"]
     }
   }
 


### PR DESCRIPTION
## Description
change service account name to establish a valid trust relationship between Kubefirst and AWS ([Link to change](https://github.com/konstructio/kubefirst-pro-api/commit/f68ea061ac665d9e48200703be9043d6b9e5ea69))