### PR TITLE
fix: Use current patch version of 1.30 on Vultr

### DIFF
--- a/vultr-github/terraform/vultr/main.tf
+++ b/vultr-github/terraform/vultr/main.tf
@@ -27,7 +27,7 @@ locals {
   pool_name            = "${local.cluster_name}-node-pool"
   pool_instance_type   = "<NODE_TYPE>"
   kube_config_filename = "../../../kubeconfig"
-  kubernetes_version   = "v1.30.3+1"
+  kubernetes_version   = "v1.30.6+1"
 }
 
 resource "vultr_kubernetes" "kubefirst" {

--- a/vultr-gitlab/terraform/vultr/main.tf
+++ b/vultr-gitlab/terraform/vultr/main.tf
@@ -27,7 +27,7 @@ locals {
   pool_name            = "${local.cluster_name}-node-pool"
   pool_instance_type   = "<NODE_TYPE>"
   kube_config_filename = "../../../kubeconfig"
-  kubernetes_version   = "v1.30.3+1"
+  kubernetes_version   = "v1.30.6+1"
 }
 
 resource "vultr_kubernetes" "kubefirst" {


### PR DESCRIPTION
## Description
This uses the current patch version of K8s on Vultr per 
## Related Issue(s)

https://github.com/konstructio/kubefirst/issues/2261

Fixes #2261 (issue in main kubefirst repo)

## How to test
Create a cluster on Vultr without this change, it will fail with an error `Invalid k8 version`. With this change, the `terraform apply` step will be successful and the `kubefirst beta vultr create ...` command is successful!
