### PR TITLE
Fix gke version

### DIFF
--- a/google-github/terraform/google/gke/nat.tf
+++ b/google-github/terraform/google/gke/nat.tf
@@ -8,6 +8,7 @@ resource "google_compute_router" "router" {
 module "cloud-nat" {
   name                               = "gke-nat-config-${var.cluster_name}"
   source                             = "terraform-google-modules/cloud-nat/google"
+  version                            = "5.3.0"
   project_id                         = var.project
   region                             = var.google_region
   router                             = google_compute_router.router.name

--- a/google-github/terraform/google/gke/nat.tf
+++ b/google-github/terraform/google/gke/nat.tf
@@ -8,7 +8,6 @@ resource "google_compute_router" "router" {
 module "cloud-nat" {
   name                               = "gke-nat-config-${var.cluster_name}"
   source                             = "terraform-google-modules/cloud-nat/google"
-  version                            = "~> 5.0"
   project_id                         = var.project
   region                             = var.google_region
   router                             = google_compute_router.router.name

--- a/google-github/terraform/google/vpc.tf
+++ b/google-github/terraform/google/vpc.tf
@@ -1,5 +1,6 @@
 module "vpc" {
   source  = "terraform-google-modules/network/google"
+  version = "10.0.0"
 
   project_id   = var.project
   network_name = "${var.network_name}-${local.cluster_name}"

--- a/google-github/terraform/google/vpc.tf
+++ b/google-github/terraform/google/vpc.tf
@@ -1,6 +1,5 @@
 module "vpc" {
   source  = "terraform-google-modules/network/google"
-  version = "~> 7.0"
 
   project_id   = var.project
   network_name = "${var.network_name}-${local.cluster_name}"

--- a/google-gitlab/terraform/google/gke/nat.tf
+++ b/google-gitlab/terraform/google/gke/nat.tf
@@ -8,7 +8,6 @@ resource "google_compute_router" "router" {
 module "cloud-nat" {
   name                               = "gke-nat-config-${var.cluster_name}"
   source                             = "terraform-google-modules/cloud-nat/google"
-  version                            = "~> 4.0"
   project_id                         = var.project
   region                             = var.google_region
   router                             = google_compute_router.router.name

--- a/google-gitlab/terraform/google/gke/nat.tf
+++ b/google-gitlab/terraform/google/gke/nat.tf
@@ -8,6 +8,7 @@ resource "google_compute_router" "router" {
 module "cloud-nat" {
   name                               = "gke-nat-config-${var.cluster_name}"
   source                             = "terraform-google-modules/cloud-nat/google"
+  version                            = "5.3.0"
   project_id                         = var.project
   region                             = var.google_region
   router                             = google_compute_router.router.name

--- a/google-gitlab/terraform/google/vpc.tf
+++ b/google-gitlab/terraform/google/vpc.tf
@@ -1,5 +1,6 @@
 module "vpc" {
   source  = "terraform-google-modules/network/google"
+  version = "10.0.0"
 
   project_id   = var.project
   network_name = "${var.network_name}-${local.cluster_name}"

--- a/google-gitlab/terraform/google/vpc.tf
+++ b/google-gitlab/terraform/google/vpc.tf
@@ -1,6 +1,5 @@
 module "vpc" {
   source  = "terraform-google-modules/network/google"
-  version = "~> 7.0"
 
   project_id   = var.project
   network_name = "${var.network_name}-${local.cluster_name}"


### PR DESCRIPTION
### **Description**  
Updated Terraform modules to resolve provider version conflicts:  
- VPC module to `10.0.0`  
- Cloud NAT module to `5.3.0`

**Before Updating**  
![Before Update 1](https://github.com/user-attachments/assets/537ed6aa-bc3b-4e7d-bf74-69080ad198bc)  
![Before Update 2](https://github.com/user-attachments/assets/08ee2c9b-4ebf-4b6a-b60e-04605005deb0)  
![Before Update 3](https://github.com/user-attachments/assets/bf7b49b7-909a-4bb0-9457-c2fdad4bd9a8)  

**After Updating**  
![After Update 1](https://github.com/user-attachments/assets/bd8c1213-e909-4b2a-b4fd-5bee099d30f2)  
![After Update 2](https://github.com/user-attachments/assets/de0e0e41-36bd-4896-9ca9-b1f600b2401c)  
![After Update 3](https://github.com/user-attachments/assets/694589ea-5ee6-48a2-aa5c-d03682caf8e8)  

## Testing  
Provision Google management with the flag `--gitops-template-branch fix-gke-version`  
Example:  
```bash
kubefirst google create \  
  --alerts-email 1@gmail.com \  
  --domain-name kuberfu.com \  
  --dns-provider cloudflare \  
  --gitops-template-branch fix-gke-version \  
  --git-provider github \  
  --github-org ar6464 \  
  --cluster-name rr19 \  
  --google-project <project-name>
