### PR TITLE
feat: update Kubernetes version to v1.31.5+1

### DIFF
--- a/vultr-github/terraform/vultr/main.tf
+++ b/vultr-github/terraform/vultr/main.tf
@@ -27,7 +27,8 @@ locals {
   pool_name            = "${local.cluster_name}-node-pool"
   pool_instance_type   = "<NODE_TYPE>"
   kube_config_filename = "../../../kubeconfig"
-  kubernetes_version   = "v1.30.6+1"
+  # List of supported versions https://api.vultr.com/v2/kubernetes/versions
+  kubernetes_version = "v1.31.5+1"
 }
 
 resource "vultr_kubernetes" "kubefirst" {

--- a/vultr-github/terraform/vultr/modules/workload-cluster/main.tf
+++ b/vultr-github/terraform/vultr/modules/workload-cluster/main.tf
@@ -1,7 +1,7 @@
 resource "vultr_kubernetes" "cluster" {
   region  = var.cluster_region
   label   = var.cluster_name
-  version = "v1.30.6+1"
+  version = "v1.31.5+1"
 
   node_pools {
     plan          = var.node_type

--- a/vultr-gitlab/terraform/vultr/main.tf
+++ b/vultr-gitlab/terraform/vultr/main.tf
@@ -27,7 +27,7 @@ locals {
   pool_name            = "${local.cluster_name}-node-pool"
   pool_instance_type   = "<NODE_TYPE>"
   kube_config_filename = "../../../kubeconfig"
-  kubernetes_version   = "v1.30.6+1"
+  kubernetes_version   = "v1.31.5+1"
 }
 
 resource "vultr_kubernetes" "kubefirst" {


### PR DESCRIPTION
## Description
Update management and workload cluster Kubernetes version to `v1.31.5+1`.

## Related Issue(s)
<!-- List the issue(s) this PR solves. An issue should be raised before creating a PR -->
Fixes #
- Vultr dropped support for `v1.30.6+1`

## How to test
Create Kubefirst platform in Vultr using this branch.