### PR TITLE
fix: metaphor for k3d

### DIFF
--- a/k3d-github/cluster-types/mgmt/components/development/metaphor/values.yaml
+++ b/k3d-github/cluster-types/mgmt/components/development/metaphor/values.yaml
@@ -20,3 +20,4 @@ metaphor:
     console: https://kubefirst.<DOMAIN_NAME>
   vaultMountPoint: kubefirst
   vaultSecretPath: development/metaphor
+  originIssuerIsEnabled: false

--- a/k3d-github/cluster-types/mgmt/components/production/metaphor/values.yaml
+++ b/k3d-github/cluster-types/mgmt/components/production/metaphor/values.yaml
@@ -20,3 +20,4 @@ metaphor:
     console: https://kubefirst.<DOMAIN_NAME>
   vaultMountPoint: kubefirst
   vaultSecretPath: production/metaphor
+  originIssuerIsEnabled: false

--- a/k3d-github/cluster-types/mgmt/components/staging/metaphor/values.yaml
+++ b/k3d-github/cluster-types/mgmt/components/staging/metaphor/values.yaml
@@ -20,3 +20,4 @@ metaphor:
     console: https://kubefirst.<DOMAIN_NAME>
   vaultMountPoint: kubefirst
   vaultSecretPath: staging/metaphor
+  originIssuerIsEnabled: false

--- a/k3d-gitlab/cluster-types/mgmt/components/development/metaphor/values.yaml
+++ b/k3d-gitlab/cluster-types/mgmt/components/development/metaphor/values.yaml
@@ -20,3 +20,4 @@ metaphor:
     console: https://kubefirst.<DOMAIN_NAME>
   vaultMountPoint: kubefirst
   vaultSecretPath: development/metaphor
+  originIssuerIsEnabled: false

--- a/k3d-gitlab/cluster-types/mgmt/components/production/metaphor/values.yaml
+++ b/k3d-gitlab/cluster-types/mgmt/components/production/metaphor/values.yaml
@@ -20,3 +20,4 @@ metaphor:
     console: https://kubefirst.<DOMAIN_NAME>
   vaultMountPoint: kubefirst
   vaultSecretPath: production/metaphor
+  originIssuerIsEnabled: false

--- a/k3d-gitlab/cluster-types/mgmt/components/staging/metaphor/values.yaml
+++ b/k3d-gitlab/cluster-types/mgmt/components/staging/metaphor/values.yaml
@@ -20,3 +20,4 @@ metaphor:
     console: https://kubefirst.<DOMAIN_NAME>
   vaultMountPoint: kubefirst
   vaultSecretPath: staging/metaphor
+  originIssuerIsEnabled: false


### PR DESCRIPTION
## Description
- Origin issuer was enabled for [Metaphor](https://github.com/konstructio/gitops-template/pull/843/files) and was causing issues for k3d. Adding `originIssuerIsEnabled: false` fix the issue

![Screenshot 2025-02-10 at 2 02 02 PM](https://github.com/user-attachments/assets/81e10d16-9fb0-4880-b970-4aff36d7217c)

![Screenshot 2025-02-10 at 2 03 37 PM](https://github.com/user-attachments/assets/a3e5fbe4-b243-42f2-8172-2b8f32fb03c2)
