### PR TITLE
feat: add ami support for gitlab

### DIFF
--- a/aws-gitlab/templates/workload-cluster/infrastructure-bootstrap/wait.yaml
+++ b/aws-gitlab/templates/workload-cluster/infrastructure-bootstrap/wait.yaml
@@ -11,7 +11,7 @@ spec:
       serviceAccountName: argocd-server
       containers:
       - name: wait
-        image: bitnami/kubectl:1.25.12
+        image: docker.io/bitnami/kubectl:1.28
         command:
         - /bin/sh
         - -c

--- a/aws-gitlab/templates/workload-cluster/infrastructure/wait.yaml
+++ b/aws-gitlab/templates/workload-cluster/infrastructure/wait.yaml
@@ -11,7 +11,7 @@ spec:
       serviceAccountName: argocd-server
       containers:
       - name: wait
-        image: bitnami/kubectl:1.25.12
+        image: docker.io/bitnami/kubectl:1.28
         command:
         - /bin/sh
         - -c

--- a/aws-gitlab/templates/workload-cluster/infrastructure/workspace.yaml
+++ b/aws-gitlab/templates/workload-cluster/infrastructure/workspace.yaml
@@ -17,3 +17,7 @@ spec:
       value: "<WORKLOAD_NODE_COUNT>"
     - key: node_type
       value: "<WORKLOAD_NODE_TYPE>"
+    - key: ami_type
+      value: "<WORKLOAD_AMI_TYPE>"
+
+


### PR DESCRIPTION
## Description
Add support for ami type in downstream clusters 

## How to test
provision the mgmt aws cluster using flag '--gitops-template-branch ami-gitlab` and provision physical clusters
