### PR TITLE
fix: add cluster creator access entry

### DIFF
--- a/aws-github/terraform/aws/eks/main.tf
+++ b/aws-github/terraform/aws/eks/main.tf
@@ -106,35 +106,17 @@ module "eks" {
   }
 
   # Enable admin permissions for the cluster creator
-  enable_cluster_creator_admin_permissions = true
+  enable_cluster_creator_admin_permissions = false
 
   access_entries = {
 
-    "argocd_<CLUSTER_NAME>" = {
-      cluster_name  = "<CLUSTER_NAME>"
-      principal_arn = "arn:aws:iam::<AWS_ACCOUNT_ID>:role/argocd-<CLUSTER_NAME>"
-      username      = "arn:aws:iam::<AWS_ACCOUNT_ID>:role/argocd-<CLUSTER_NAME>"
+    "cluster_creator" = {
+      principal_arn = "<AWS_IAM_CALLER_ARN>"
       policy_associations = {
-        view_deployments = {
-          policy_arn = "arn:aws:eks::aws:cluster-access-policy/AmazonEKSViewPolicy"
+        admin_permission = {
+          policy_arn = "arn:aws:eks::aws:cluster-access-policy/AmazonEKSClusterAdminPolicy"
           access_scope = {
-            namespaces = ["default"]
-            type       = "namespace"
-          }
-        }
-      }
-    }
-
-    "atlantis_<CLUSTER_NAME>" = {
-      cluster_name  = "<CLUSTER_NAME>"
-      principal_arn = "arn:aws:iam::<AWS_ACCOUNT_ID>:role/atlantis-<CLUSTER_NAME>"
-      username      = "arn:aws:iam::<AWS_ACCOUNT_ID>:role/atlantis-<CLUSTER_NAME>"
-      policy_associations = {
-        view_deployments = {
-          policy_arn = "arn:aws:eks::aws:cluster-access-policy/AmazonEKSViewPolicy"
-          access_scope = {
-            namespaces = ["default"]
-            type       = "namespace"
+            type = "cluster"
           }
         }
       }
@@ -616,7 +598,7 @@ EOT
 }
 
 resource "aws_iam_policy" "ssm_access_policy" {
-  name = "kubefirst-pro-api-ssm-access-${local.name}"
+  name        = "kubefirst-pro-api-ssm-access-${local.name}"
   description = "Policy to allow SSM actions for kubefirst-pro-api"
   policy = jsonencode({
     Version = "2012-10-17",

--- a/aws-github/terraform/aws/eks/main.tf
+++ b/aws-github/terraform/aws/eks/main.tf
@@ -109,7 +109,6 @@ module "eks" {
   enable_cluster_creator_admin_permissions = false
 
   access_entries = {
-
     "cluster_creator" = {
       principal_arn = "<AWS_IAM_CALLER_ARN>"
       policy_associations = {


### PR DESCRIPTION
## Description
PR add a cluster creator access entry.  I have removed ArgoCD and Atlant's Access etnry aad they were only AmazonEKSViewPolicy in the default namespace.

## Related Issue(s)
<!-- List the issue(s) this PR solves. An issue should be raised before creating a PR -->
Fixes #
When `enable_cluster_creator_admin_permissions` is enabled. It creates an access policy based on the idenity caller. <add explanation> You get the following error. 
```
running "/atlantis-data/bin/terraform1.3.8 apply -input=false \"/atlantis-data/repos/k1-aws/gitops/1/default/terraform/aws/default.tfplan\"" in "/atlantis-data/repos/k1-aws/gitops/1/default/terraform/aws": exit status 1
module.eks.module.eks.aws_eks_access_policy_association.this["cluster_creator_admin"]: Destroying... [id=ci-k1-8ddf1835-aws-gh-cf#arn:aws:iam::<accountID>:role/KubernetesAdmin#arn:aws:eks::aws:cluster-access-policy/AmazonEKSClusterAdminPolicy]
module.eks.module.eks.aws_eks_access_policy_association.this["cluster_creator_admin"]: Destruction complete after 1s
module.eks.module.eks.aws_eks_access_entry.this["cluster_creator"]: Destroying... [id=ci-k1-8ddf1835-aws-gh-cf:arn:aws:iam::126827061464:role/KubernetesAdmin]
module.eks.module.eks.aws_eks_access_entry.this["cluster_creator"]: Destruction complete after 0s
module.eks.module.eks.aws_eks_access_entry.this["cluster_creator"]: Creating...
╷
│ Error: creating EKS Access Entry (ci-k1-8ddf1835-aws-gh-cf:arn:aws:iam::<accountID>:role/atlantis-ci-k1-8ddf1835-aws-gh-cf): operation error EKS: CreateAccessEntry, https response error StatusCode: 409, RequestID: <requestID>, ResourceInUseException: The specified access entry resource is already in use on this cluster.
│ 
│   with module.eks.module.eks.aws_eks_access_entry.this["cluster_creator"],
│   on .terraform/modules/eks.eks/main.tf line 185, in resource "aws_eks_access_entry" "this":
│  185: resource "aws_eks_access_entry" "this" {
│ 
╵
```
## How to test
<!-- Provide steps to test this PR -->
