### PR TITLE
upgrading nginx to 4.12.1 for the next release

### DIFF
--- a/akamai-github/templates/mgmt/components/ingress-nginx/application.yaml
+++ b/akamai-github/templates/mgmt/components/ingress-nginx/application.yaml
@@ -11,7 +11,7 @@ spec:
   project: default
   source:
     repoURL: https://kubernetes.github.io/ingress-nginx
-    targetRevision: 4.10.0
+    targetRevision: 4.12.1
     helm:
       values: |-
         controller:

--- a/akamai-github/templates/workload-cluster/30-ingress-nginx.yaml
+++ b/akamai-github/templates/workload-cluster/30-ingress-nginx.yaml
@@ -11,7 +11,7 @@ spec:
   project: <WORKLOAD_CLUSTER_NAME>
   source:
     repoURL: https://kubernetes.github.io/ingress-nginx
-    targetRevision: 4.10.0
+    targetRevision: 4.12.1
     helm:
       values: |-
         controller:

--- a/akamai-github/templates/workload-vcluster/30-ingress-nginx.yaml
+++ b/akamai-github/templates/workload-vcluster/30-ingress-nginx.yaml
@@ -11,7 +11,7 @@ spec:
   project: <WORKLOAD_CLUSTER_NAME>
   source:
     repoURL: https://kubernetes.github.io/ingress-nginx
-    targetRevision: 4.10.0
+    targetRevision: 4.12.1
     helm:
       values: |-
         controller:

--- a/aws-github/templates/mgmt/components/ingress-nginx/application.yaml
+++ b/aws-github/templates/mgmt/components/ingress-nginx/application.yaml
@@ -11,7 +11,7 @@ spec:
   project: default
   source:
     repoURL: https://kubernetes.github.io/ingress-nginx
-    targetRevision: 4.10.0
+    targetRevision: 4.12.1
     helm:
       values: |-
         controller:

--- a/aws-github/templates/workload-cluster/30-ingress-nginx.yaml
+++ b/aws-github/templates/workload-cluster/30-ingress-nginx.yaml
@@ -11,7 +11,7 @@ spec:
   project: <WORKLOAD_CLUSTER_NAME>
   source:
     repoURL: https://kubernetes.github.io/ingress-nginx
-    targetRevision: 4.10.0
+    targetRevision: 4.12.1
     helm:
       values: |-
         controller:

--- a/aws-github/templates/workload-vcluster/30-ingress-nginx.yaml
+++ b/aws-github/templates/workload-vcluster/30-ingress-nginx.yaml
@@ -11,7 +11,7 @@ spec:
   project: <WORKLOAD_CLUSTER_NAME>
   source:
     repoURL: https://kubernetes.github.io/ingress-nginx
-    targetRevision: 4.10.0
+    targetRevision: 4.12.1
     helm:
       values: |-
         controller:

--- a/aws-gitlab/templates/mgmt/components/ingress-nginx/application.yaml
+++ b/aws-gitlab/templates/mgmt/components/ingress-nginx/application.yaml
@@ -11,7 +11,7 @@ spec:
   project: default
   source:
     repoURL: https://kubernetes.github.io/ingress-nginx
-    targetRevision: 4.10.0
+    targetRevision: 4.12.1
     helm:
       values: |-
         controller:

--- a/aws-gitlab/templates/workload-cluster/30-ingress-nginx.yaml
+++ b/aws-gitlab/templates/workload-cluster/30-ingress-nginx.yaml
@@ -11,7 +11,7 @@ spec:
   project: <WORKLOAD_CLUSTER_NAME>
   source:
     repoURL: https://kubernetes.github.io/ingress-nginx
-    targetRevision: 4.10.0
+    targetRevision: 4.12.1
     helm:
       values: |-
         controller:

--- a/aws-gitlab/templates/workload-vcluster/30-ingress-nginx.yaml
+++ b/aws-gitlab/templates/workload-vcluster/30-ingress-nginx.yaml
@@ -11,7 +11,7 @@ spec:
   project: <WORKLOAD_CLUSTER_NAME>
   source:
     repoURL: https://kubernetes.github.io/ingress-nginx
-    targetRevision: 4.10.0
+    targetRevision: 4.12.1
     helm:
       values: |-
         controller:

--- a/azure-github/templates/mgmt/components/ingress-nginx/application.yaml
+++ b/azure-github/templates/mgmt/components/ingress-nginx/application.yaml
@@ -11,7 +11,7 @@ spec:
   project: default
   source:
     repoURL: https://kubernetes.github.io/ingress-nginx
-    targetRevision: 4.10.0
+    targetRevision: 4.12.1
     helm:
       values: |-
         controller:

--- a/azure-github/templates/workload-cluster/30-ingress-nginx.yaml
+++ b/azure-github/templates/workload-cluster/30-ingress-nginx.yaml
@@ -11,7 +11,7 @@ spec:
   project: <WORKLOAD_CLUSTER_NAME>
   source:
     repoURL: https://kubernetes.github.io/ingress-nginx
-    targetRevision: 4.10.0
+    targetRevision: 4.12.1
     helm:
       values: |-
         controller:

--- a/azure-github/templates/workload-vcluster/30-ingress-nginx.yaml
+++ b/azure-github/templates/workload-vcluster/30-ingress-nginx.yaml
@@ -11,7 +11,7 @@ spec:
   project: <WORKLOAD_CLUSTER_NAME>
   source:
     repoURL: https://kubernetes.github.io/ingress-nginx
-    targetRevision: 4.10.0
+    targetRevision: 4.12.1
     helm:
       values: |-
         controller:

--- a/azure-gitlab/templates/mgmt/components/ingress-nginx/application.yaml
+++ b/azure-gitlab/templates/mgmt/components/ingress-nginx/application.yaml
@@ -11,7 +11,7 @@ spec:
   project: default
   source:
     repoURL: https://kubernetes.github.io/ingress-nginx
-    targetRevision: 4.10.0
+    targetRevision: 4.12.1
     helm:
       values: |-
         controller:

--- a/azure-gitlab/templates/workload-cluster/30-ingress-nginx.yaml
+++ b/azure-gitlab/templates/workload-cluster/30-ingress-nginx.yaml
@@ -11,7 +11,7 @@ spec:
   project: <WORKLOAD_CLUSTER_NAME>
   source:
     repoURL: https://kubernetes.github.io/ingress-nginx
-    targetRevision: 4.10.0
+    targetRevision: 4.12.1
     helm:
       values: |-
         controller:

--- a/azure-gitlab/templates/workload-vcluster/30-ingress-nginx.yaml
+++ b/azure-gitlab/templates/workload-vcluster/30-ingress-nginx.yaml
@@ -11,7 +11,7 @@ spec:
   project: <WORKLOAD_CLUSTER_NAME>
   source:
     repoURL: https://kubernetes.github.io/ingress-nginx
-    targetRevision: 4.10.0
+    targetRevision: 4.12.1
     helm:
       values: |-
         controller:

--- a/civo-github/templates/gpu-cluster/30-ingress-nginx.yaml
+++ b/civo-github/templates/gpu-cluster/30-ingress-nginx.yaml
@@ -11,7 +11,7 @@ spec:
   project: <WORKLOAD_CLUSTER_NAME>
   source:
     repoURL: https://kubernetes.github.io/ingress-nginx
-    targetRevision: 4.10.0
+    targetRevision: 4.12.1
     helm:
       values: |-
         controller:

--- a/civo-github/templates/mgmt/components/ingress-nginx/application.yaml
+++ b/civo-github/templates/mgmt/components/ingress-nginx/application.yaml
@@ -11,7 +11,7 @@ spec:
   project: default
   source:
     repoURL: https://kubernetes.github.io/ingress-nginx
-    targetRevision: 4.10.0
+    targetRevision: 4.12.1
     helm:
       values: |-
         controller:

--- a/civo-github/templates/workload-cluster/30-ingress-nginx.yaml
+++ b/civo-github/templates/workload-cluster/30-ingress-nginx.yaml
@@ -11,7 +11,7 @@ spec:
   project: <WORKLOAD_CLUSTER_NAME>
   source:
     repoURL: https://kubernetes.github.io/ingress-nginx
-    targetRevision: 4.10.0
+    targetRevision: 4.12.1
     helm:
       values: |-
         controller:

--- a/civo-github/templates/workload-vcluster/30-ingress-nginx.yaml
+++ b/civo-github/templates/workload-vcluster/30-ingress-nginx.yaml
@@ -11,7 +11,7 @@ spec:
   project: <WORKLOAD_CLUSTER_NAME>
   source:
     repoURL: https://kubernetes.github.io/ingress-nginx
-    targetRevision: 4.10.0
+    targetRevision: 4.12.1
     helm:
       values: |-
         controller:

--- a/civo-gitlab/templates/gpu-cluster/30-ingress-nginx.yaml
+++ b/civo-gitlab/templates/gpu-cluster/30-ingress-nginx.yaml
@@ -11,7 +11,7 @@ spec:
   project: <WORKLOAD_CLUSTER_NAME>
   source:
     repoURL: https://kubernetes.github.io/ingress-nginx
-    targetRevision: 4.10.0
+    targetRevision: 4.12.1
     helm:
       values: |-
         controller:

--- a/civo-gitlab/templates/mgmt/components/ingress-nginx/application.yaml
+++ b/civo-gitlab/templates/mgmt/components/ingress-nginx/application.yaml
@@ -11,7 +11,7 @@ spec:
   project: default
   source:
     repoURL: https://kubernetes.github.io/ingress-nginx
-    targetRevision: 4.10.0
+    targetRevision: 4.12.1
     helm:
       values: |-
         controller:

--- a/civo-gitlab/templates/workload-cluster/30-ingress-nginx.yaml
+++ b/civo-gitlab/templates/workload-cluster/30-ingress-nginx.yaml
@@ -11,7 +11,7 @@ spec:
   project: <WORKLOAD_CLUSTER_NAME>
   source:
     repoURL: https://kubernetes.github.io/ingress-nginx
-    targetRevision: 4.10.0
+    targetRevision: 4.12.1
     helm:
       values: |-
         controller:

--- a/civo-gitlab/templates/workload-vcluster/30-ingress-nginx.yaml
+++ b/civo-gitlab/templates/workload-vcluster/30-ingress-nginx.yaml
@@ -11,7 +11,7 @@ spec:
   project: <WORKLOAD_CLUSTER_NAME>
   source:
     repoURL: https://kubernetes.github.io/ingress-nginx
-    targetRevision: 4.10.0
+    targetRevision: 4.12.1
     helm:
       values: |-
         controller:

--- a/digitalocean-github/templates/mgmt/components/ingress-nginx/application.yaml
+++ b/digitalocean-github/templates/mgmt/components/ingress-nginx/application.yaml
@@ -11,7 +11,7 @@ spec:
   project: default
   source:
     repoURL: https://kubernetes.github.io/ingress-nginx
-    targetRevision: 4.10.0
+    targetRevision: 4.12.1
     helm:
       values: |-
         controller:

--- a/digitalocean-github/templates/workload-cluster/30-ingress-nginx.yaml
+++ b/digitalocean-github/templates/workload-cluster/30-ingress-nginx.yaml
@@ -11,7 +11,7 @@ spec:
   project: <WORKLOAD_CLUSTER_NAME>
   source:
     repoURL: https://kubernetes.github.io/ingress-nginx
-    targetRevision: 4.10.0
+    targetRevision: 4.12.1
     helm:
       values: |-
         controller:

--- a/digitalocean-github/templates/workload-vcluster/30-ingress-nginx.yaml
+++ b/digitalocean-github/templates/workload-vcluster/30-ingress-nginx.yaml
@@ -11,7 +11,7 @@ spec:
   project: <WORKLOAD_CLUSTER_NAME>
   source:
     repoURL: https://kubernetes.github.io/ingress-nginx
-    targetRevision: 4.10.0
+    targetRevision: 4.12.1
     helm:
       values: |-
         controller:

--- a/digitalocean-gitlab/templates/mgmt/components/ingress-nginx/application.yaml
+++ b/digitalocean-gitlab/templates/mgmt/components/ingress-nginx/application.yaml
@@ -11,7 +11,7 @@ spec:
   project: default
   source:
     repoURL: https://kubernetes.github.io/ingress-nginx
-    targetRevision: 4.10.0
+    targetRevision: 4.12.1
     helm:
       values: |-
         controller:

--- a/digitalocean-gitlab/templates/workload-cluster/30-ingress-nginx.yaml
+++ b/digitalocean-gitlab/templates/workload-cluster/30-ingress-nginx.yaml
@@ -11,7 +11,7 @@ spec:
   project: <WORKLOAD_CLUSTER_NAME>
   source:
     repoURL: https://kubernetes.github.io/ingress-nginx
-    targetRevision: 4.10.0
+    targetRevision: 4.12.1
     helm:
       values: |-
         controller:

--- a/digitalocean-gitlab/templates/workload-vcluster/30-ingress-nginx.yaml
+++ b/digitalocean-gitlab/templates/workload-vcluster/30-ingress-nginx.yaml
@@ -11,7 +11,7 @@ spec:
   project: <WORKLOAD_CLUSTER_NAME>
   source:
     repoURL: https://kubernetes.github.io/ingress-nginx
-    targetRevision: 4.10.0
+    targetRevision: 4.12.1
     helm:
       values: |-
         controller:

--- a/google-github/templates/mgmt/components/ingress-nginx/application.yaml
+++ b/google-github/templates/mgmt/components/ingress-nginx/application.yaml
@@ -11,7 +11,7 @@ spec:
   project: default
   source:
     repoURL: https://kubernetes.github.io/ingress-nginx
-    targetRevision: 4.10.0
+    targetRevision: 4.12.1
     helm:
       values: |-
         controller:

--- a/google-github/templates/workload-cluster/30-ingress-nginx.yaml
+++ b/google-github/templates/workload-cluster/30-ingress-nginx.yaml
@@ -11,7 +11,7 @@ spec:
   project: <WORKLOAD_CLUSTER_NAME>
   source:
     repoURL: https://kubernetes.github.io/ingress-nginx
-    targetRevision: 4.10.0
+    targetRevision: 4.12.1
     helm:
       values: |-
         controller:

--- a/google-github/templates/workload-vcluster/30-ingress-nginx.yaml
+++ b/google-github/templates/workload-vcluster/30-ingress-nginx.yaml
@@ -11,7 +11,7 @@ spec:
   project: <WORKLOAD_CLUSTER_NAME>
   source:
     repoURL: https://kubernetes.github.io/ingress-nginx
-    targetRevision: 4.10.0
+    targetRevision: 4.12.1
     helm:
       values: |-
         controller:

--- a/google-gitlab/templates/mgmt/components/ingress-nginx/application.yaml
+++ b/google-gitlab/templates/mgmt/components/ingress-nginx/application.yaml
@@ -11,7 +11,7 @@ spec:
   project: default
   source:
     repoURL: https://kubernetes.github.io/ingress-nginx
-    targetRevision: 4.10.0
+    targetRevision: 4.12.1
     helm:
       values: |-
         controller:

--- a/google-gitlab/templates/workload-cluster/30-ingress-nginx.yaml
+++ b/google-gitlab/templates/workload-cluster/30-ingress-nginx.yaml
@@ -11,7 +11,7 @@ spec:
   project: <WORKLOAD_CLUSTER_NAME>
   source:
     repoURL: https://kubernetes.github.io/ingress-nginx
-    targetRevision: 4.10.0
+    targetRevision: 4.12.1
     helm:
       values: |-
         controller:

--- a/google-gitlab/templates/workload-vcluster/30-ingress-nginx.yaml
+++ b/google-gitlab/templates/workload-vcluster/30-ingress-nginx.yaml
@@ -11,7 +11,7 @@ spec:
   project: <WORKLOAD_CLUSTER_NAME>
   source:
     repoURL: https://kubernetes.github.io/ingress-nginx
-    targetRevision: 4.10.0
+    targetRevision: 4.12.1
     helm:
       values: |-
         controller:

--- a/k3s-github/templates/mgmt/components/ingress-nginx/application.yaml
+++ b/k3s-github/templates/mgmt/components/ingress-nginx/application.yaml
@@ -11,7 +11,7 @@ spec:
   project: default
   source:
     repoURL: https://kubernetes.github.io/ingress-nginx
-    targetRevision: 4.10.0
+    targetRevision: 4.12.1
     helm:
       values: |-
         controller:

--- a/k3s-github/templates/workload-vcluster/30-ingress-nginx.yaml
+++ b/k3s-github/templates/workload-vcluster/30-ingress-nginx.yaml
@@ -11,7 +11,7 @@ spec:
   project: <WORKLOAD_CLUSTER_NAME>
   source:
     repoURL: https://kubernetes.github.io/ingress-nginx
-    targetRevision: 4.10.0
+    targetRevision: 4.12.1
     helm:
       values: |-
         controller:

--- a/k3s-gitlab/templates/mgmt/components/ingress-nginx/application.yaml
+++ b/k3s-gitlab/templates/mgmt/components/ingress-nginx/application.yaml
@@ -11,7 +11,7 @@ spec:
   project: default
   source:
     repoURL: https://kubernetes.github.io/ingress-nginx
-    targetRevision: 4.10.0
+    targetRevision: 4.12.1
     helm:
       values: |-
         controller:

--- a/k3s-gitlab/templates/workload-vcluster/30-ingress-nginx.yaml
+++ b/k3s-gitlab/templates/workload-vcluster/30-ingress-nginx.yaml
@@ -11,7 +11,7 @@ spec:
   project: <WORKLOAD_CLUSTER_NAME>
   source:
     repoURL: https://kubernetes.github.io/ingress-nginx
-    targetRevision: 4.10.0
+    targetRevision: 4.12.1
     helm:
       values: |-
         controller:

--- a/vultr-github/templates/gpu-cluster/30-ingress-nginx.yaml
+++ b/vultr-github/templates/gpu-cluster/30-ingress-nginx.yaml
@@ -11,7 +11,7 @@ spec:
   project: <WORKLOAD_CLUSTER_NAME>
   source:
     repoURL: https://kubernetes.github.io/ingress-nginx
-    targetRevision: 4.10.0
+    targetRevision: 4.12.1
     helm:
       values: |-
         controller:

--- a/vultr-github/templates/mgmt/components/ingress-nginx/application.yaml
+++ b/vultr-github/templates/mgmt/components/ingress-nginx/application.yaml
@@ -11,7 +11,7 @@ spec:
   project: default
   source:
     repoURL: https://kubernetes.github.io/ingress-nginx
-    targetRevision: 4.10.0
+    targetRevision: 4.12.1
     helm:
       values: |-
         controller:

--- a/vultr-github/templates/workload-cluster/30-ingress-nginx.yaml
+++ b/vultr-github/templates/workload-cluster/30-ingress-nginx.yaml
@@ -11,7 +11,7 @@ spec:
   project: <WORKLOAD_CLUSTER_NAME>
   source:
     repoURL: https://kubernetes.github.io/ingress-nginx
-    targetRevision: 4.10.0
+    targetRevision: 4.12.1
     helm:
       values: |-
         controller:

--- a/vultr-github/templates/workload-vcluster/30-ingress-nginx.yaml
+++ b/vultr-github/templates/workload-vcluster/30-ingress-nginx.yaml
@@ -11,7 +11,7 @@ spec:
   project: <WORKLOAD_CLUSTER_NAME>
   source:
     repoURL: https://kubernetes.github.io/ingress-nginx
-    targetRevision: 4.10.0
+    targetRevision: 4.12.1
     helm:
       values: |-
         controller:

--- a/vultr-gitlab/templates/mgmt/components/ingress-nginx/application.yaml
+++ b/vultr-gitlab/templates/mgmt/components/ingress-nginx/application.yaml
@@ -11,7 +11,7 @@ spec:
   project: default
   source:
     repoURL: https://kubernetes.github.io/ingress-nginx
-    targetRevision: 4.10.0
+    targetRevision: 4.12.1
     helm:
       values: |-
         controller:

--- a/vultr-gitlab/templates/workload-cluster/30-ingress-nginx.yaml
+++ b/vultr-gitlab/templates/workload-cluster/30-ingress-nginx.yaml
@@ -11,7 +11,7 @@ spec:
   project: <WORKLOAD_CLUSTER_NAME>
   source:
     repoURL: https://kubernetes.github.io/ingress-nginx
-    targetRevision: 4.10.0
+    targetRevision: 4.12.1
     helm:
       values: |-
         controller:

--- a/vultr-gitlab/templates/workload-vcluster/30-ingress-nginx.yaml
+++ b/vultr-gitlab/templates/workload-vcluster/30-ingress-nginx.yaml
@@ -11,7 +11,7 @@ spec:
   project: <WORKLOAD_CLUSTER_NAME>
   source:
     repoURL: https://kubernetes.github.io/ingress-nginx
-    targetRevision: 4.10.0
+    targetRevision: 4.12.1
     helm:
       values: |-
         controller:


### PR DESCRIPTION
## Description

see https://www.wiz.io/blog/ingress-nginx-kubernetes-vulnerabilities