### PR TITLE
fix: aws disable ipv6 for workload clusters

### DIFF
--- a/aws-github/terraform/aws/modules/workload-cluster/main.tf
+++ b/aws-github/terraform/aws/modules/workload-cluster/main.tf
@@ -120,12 +120,8 @@ module "vpc" {
   public_subnets  = [for k, v in local.azs : cidrsubnet(local.vpc_cidr, 8, k + 48)]
   intra_subnets   = [for k, v in local.azs : cidrsubnet(local.vpc_cidr, 8, k + 52)]
 
-  enable_ipv6            = true
-  create_egress_only_igw = true
-
-  public_subnet_ipv6_prefixes  = [0, 1, 2]
-  private_subnet_ipv6_prefixes = [3, 4, 5]
-  intra_subnet_ipv6_prefixes   = [6, 7, 8]
+  enable_ipv6            = false
+  create_egress_only_igw = false
 
   enable_nat_gateway   = true
   single_nat_gateway   = true


### PR DESCRIPTION
## Description

- Disables ipv6 for aws workload clusters
